### PR TITLE
Replace CMakeLists.txt build with setuptools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,0 @@
-cmake_minimum_required(VERSION 3.12)
-project(integrationtest VERSION 0.0.1)
-
-find_package(daq-cmake REQUIRED)
-
-daq_setup_environment()
-
-daq_install()

--- a/README.md
+++ b/README.md
@@ -4,18 +4,9 @@ This package provides a simple framework for integration tests of the DUNE DAQ s
 
 # How-to
 
-You must already have a python configuration generator that produces json that can be run with nanorc. Clone this package (`integrationtest`) into `$DBT_AREA_ROOT/sourcecode` as usual, then:
+You must already have a python configuration generator that produces json that can be run with nanorc. Clone this package (`integrationtest`) into `$DBT_AREA_ROOT/sourcecode` as usual, then install with `pip install .` (run in the `integrationtest` directory)
 
-1. Install this package's python dependencies into the working area's python virtualenv with `pip install -r requirements.txt`
-2. Run `dbt-build.sh` to make sure the framework python files are placed somewhere that your tests can find them
-3. Run `dbt-workarea-env` (or `dbt-workarea-env --refresh`) to ensure `integrationtest` paths are in your environment
-
-Now you can write your own tests. First, create a file `conftest.py` in the directory where your tests will live, containing these two lines:
-
-```python
-import pytest
-pytest_plugins = [ "integrationtest.integrationtest" ]
-```
+Now you can write your own tests.
 
 Explaining how to write tests is probably easiest with an example. Each test file should be named `test_*.py` or `*_test.py` to follow pytest's [conventions for Python test discovery](https://docs.pytest.org/en/6.2.x/goodpractices.html#test-discovery). Here's `test_integration.py`:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,14 @@
+[metadata]
+name = integrationtest
+version = 0.1
+url = https://github.com/DUNE-DAQ/integrationtest
+long_description = file: README.md
+long_description_content_type = text/markdown
+
+[options]
+packages = integrationtest
+package_dir = =python
+include_package_data = true
+python_requires = >= 3.6
+# Dependencies are in setup.py for GitHub's dependency graph.
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+# Metadata goes in setup.cfg. These are here for GitHub's dependency graph.
+setup(
+    name="integrationtest",
+    install_requires=[
+        "pytest",
+    ],
+    # the following makes a plugin available to pytest
+    entry_points={"pytest11": ["name_of_plugin = integrationtest.integrationtest"]},
+)


### PR DESCRIPTION
This PR replaces integrationtest's `CMakeLists.txt` with python `setuptools`. I copied and modified the `setup.cfg` and `setup.py` from `nanorc`. Happily, with the setuptools install, it's no longer necessary for test writers to create a `conftest.py` file to use `integrationtest`, so I've updated the README to reflect that.