### PR TITLE
Add --connectivity-service option to enable ConnectivityService 

### DIFF
--- a/python/integrationtest/integrationtest_nanorc.py
+++ b/python/integrationtest/integrationtest_nanorc.py
@@ -36,6 +36,13 @@ def pytest_addoption(parser):
         help="Repeatable, nanorc arguments without leading dashes (e.g. kerberos)",
         required=False
     )
+    parser.addoption(
+        "--connectivity-service",
+        action="store_true",
+        default=False,
+        help="Whether to run this test using the Connectivity Service",
+        required=False
+    )
 
 def pytest_configure(config):
     for opt in ("--nanorc-path", "--frame-file"):
@@ -98,6 +105,8 @@ def create_json_files(request, tmp_path_factory):
 
     hardware_map_required = getattr(request.module, "hardware_map_required", True)
 
+    use_connectivity_service = request.config.getoption("--connectivity-service")
+
     class CreateJsonResult:
         pass
 
@@ -115,6 +124,10 @@ def create_json_files(request, tmp_path_factory):
         with open(hardware_map_file, 'w+') as f:
             f.write(hardware_map_contents)
             f.close()
+
+    if use_connectivity_service:
+        conf_dict["boot"]["use_connectivity_service"] = True
+        conf_dict["boot"]["start_connectivity_service"] = True
 
     write_config(configfile, conf_dict)
 


### PR DESCRIPTION
and auto-start for that test run.

e.g. pytest -s sourcecode/listrev/integtest/listrev_test.py --connectivity-service


Depends on https://github.com/DUNE-DAQ/microservices/pull/30, and both (current) develop `nanorc` and the ConnectivityService from that branch being installed in the pyvenv.