### PR TITLE
Remove RandomTCMaker from FakeHSI config, let the HSI make all TCs

### DIFF
--- a/python/integrationtest/config/trigger-segment-fakehsi.data.xml
+++ b/python/integrationtest/config/trigger-segment-fakehsi.data.xml
@@ -172,7 +172,6 @@
  <rel name="trigger_inputs_handler" class="DataHandlerConf" id="def-tc-handler"/>
  <rel name="mlt_conf" class="MLTConf" id="def-mlt-conf"/>
  <rel name="standalone_candidate_maker_confs">
-  <ref class="RandomTCMakerConf" id="random-tc-generator"/>
  </rel>
 </obj>
 
@@ -187,14 +186,6 @@
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
   <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
  <rel name="broadcaster" class="RCBroadcaster" id="broadcaster-root"/>
-</obj>
-
-<obj class="RandomTCMakerConf" id="random-tc-generator">
- <attr name="timestamp_method" type="enum" val="kTimeSync"/>
- <attr name="template_for" type="class" val="RandomTCMakerModule"/>
- <attr name="trigger_interval_ticks" type="u32" val="62500000"/>
- <attr name="clock_frequency_hz" type="u32" val="62500000"/>
- <attr name="time_distribution" type="enum" val="kUniform"/>
 </obj>
 
 <obj class="DataHandlerConf" id="def-ta-handler">

--- a/python/integrationtest/integrationtest_drunc.py
+++ b/python/integrationtest/integrationtest_drunc.py
@@ -252,6 +252,23 @@ def create_config_files(request, tmp_path_factory):
     db.update_dal(detector_conf)
     db.commit()
 
+    if "trigger" in conf_dict.keys() and "ttcm_input_map" in conf_dict["trigger"].keys():
+        tcrms = db.get_dals(class_name = "TCReadoutMap")
+
+        for input_map_entry in conf_dict["trigger"]["ttcm_input_map"]:
+            signal_matched = False
+            signal = input_map_entry["signal"]
+            for tcrm in tcrms:
+                if tcrm.candidate_type == signal:
+                    signal_matched = True
+                    tcrm.time_before = input_map_entry["time_before"]
+                    tcrm.time_after = input_map_entry["time_after"]
+                    db.update_dal(tcrm)
+
+            if not signal_matched:
+                print(f"WARNING: Could not find matching TCReadoutMap entry for signal type {signal}")
+        db.commit()
+
     conf_dict["boot"]["use_connectivity_service"] = True
     if disable_connectivity_service:
         conf_dict["boot"]["use_connectivity_service"] = False


### PR DESCRIPTION
Read conf_dict["trigger"]["ttcm_input_map"] and apply settings to TCReadoutMap entries in DB.

Needed for daqsystemtest integration tests long_wingow_readout_test and small_footprint_quick_test.