### PR TITLE
Change the connectivity service port after consolidating to the resolved

### DIFF
--- a/python/integrationtest/integrationtest_drunc.py
+++ b/python/integrationtest/integrationtest_drunc.py
@@ -167,13 +167,13 @@ def create_config_files(request, tmp_path_factory):
             disable_connectivity_service=disable_connectivity_service,
         )
 
+    consolidate_db(str(temp_config_db), str(config_db))
+
     drunc_config.connsvc_port = set_connectivity_service_port(
-        oksfile=str(temp_config_db),
+        oksfile=str(config_db),
         session_name=drunc_config.session,
         connsvc_port=drunc_config.connsvc_port, # Default is 0, which causes random port to be selected
     )
-
-    consolidate_db(str(temp_config_db), str(config_db))
 
     dal = conffwk.dal.module("generated", "schema/appmodel/fdmodules.schema.xml")
     db = conffwk.Configuration("oksconflibs:" + str(config_db))


### PR DESCRIPTION
database, so that when running with a preconfigured configuration the source files aren't touched.