### PR TITLE
Enhacements to the data_file_checks that are used to validate data produced in integtests

### DIFF
--- a/docs/DataFileCheckParameters.md
+++ b/docs/DataFileCheckParameters.md
@@ -2,7 +2,7 @@
 
 This package (_integrationtest_) provides infrastructure that we use for developing and running automated integration and regression tests.  Part of what is provided is a set of functions that can be used to validate the DAQ data that is produced in such tests.  Many of these functions are contained in _data_file_checks.py_ (located in the _python/integrationtest_ subdirectory).
 
-The functions that are provided in _data_file_checks._py have been written in a way that they can be used for different types of DAQ data (for example, TriggerRecords and TimeSlices, and/or WIBEth data and data fragments produced by the Trigger system).  The way that integtest developers specify the type of data that should be tested, and the success criteria that should be used, is by passing in a Python dictionary that contains specific values for a set of expected parameters.  
+The functions that are provided in _data_file_checks.py_ have been written in a way that they can be used for different types of DAQ data (for example, TriggerRecords and TimeSlices, and/or WIBEth data and data fragments produced by the Trigger system).  The way that integtest developers specify the type of data that should be tested, and the success criteria that should be used, is by passing in a Python dictionary that contains a specified set of expected parameters.  
 
 Here is a simple example:
 ```
@@ -34,8 +34,23 @@ wibeth_tpset_params = {
 }
 ```
 
-The current set of supported parameters is the following:
+The current set of parameters that are used by multiple data-file-check functions is the following:
 
-- fragment_type - the value for this parameter needs to be a string that matches one of the defined ones in daqdataformats/FragmentHeader.hpp.
+- fragment_type - a string that matches one of the available fragment types in daqdataformats/FragmentHeader.hpp.  Users specify which fragment type they want to be tested by specifying this parameter value.
+- subdetector - a string that matches one of the available subdetector types in detdataformats/DetID.hpp.  Users can optionally specify the subdetector type for the fragments that they want to be tested with this parameter.  If no value is specified for this parameter, all subdetector types are tested.
 - fragment_type_description - this is a short string that will be used to describe the fragment type in general terms in console output from the data-file-checks.
-- debug_mask - 
+- debug_mask - a numeric value that tells the data-file-check functions which debug messages to print out, if any.  As is typical, 0x0 indicates no debug messages, and lower-number bits enable the more basic debugging printouts.
+
+The following parameters are used by the check_fragment_count() function:
+
+- expected_fragment_count - a numeric value that simply specifies the expected number of fragments
+- frag_counts_by_TC_type - a dictionary that specifies minimum and maximum fragment count values as a function of the TriggerCandiate type of the record in the file (e.g. kTiming, kPrescale, kRandom).  This allows different fragment count limites to be specified for different TC types.  There is support specifying a range to be used if the TC type of a given record doesn't have a match in the other entries in the dictionary (the "default").
+- frag_counts_by_record_ordinal - a dictionary that specifies minimum and maximum fragment count values by the ordinal number of the record in the file (e.g. first, second, penultimate, last).  This allows different fragment count limites to be specified for different records in the file.  There is support specifying a range to be used if the ordinal number of a given record doesn't have a match in the other entries in the dictionary (the "default").
+
+One or more of these parameters needs to be specified.  If multiple ones are provided, later ones in the list above "win".  So, for example, the record ordinal values over-ride the other two.
+
+The check_fragment_sizes() function expects analagous parameters, that is
+
+- min_size_bytes and max_size_bytes
+- frag_sizes_by_TC_type
+- frag_sizes_by_record_ordinal

--- a/docs/DataFileCheckParameters.md
+++ b/docs/DataFileCheckParameters.md
@@ -1,10 +1,41 @@
-# Parameters that can be used to control data-file-check behavior
+# Parameters that should be used to control data-file-check behavior
 
-This package (_integrationtest_) provides infrastructure that we use for developing and running automated integration and regression tests.
+This package (_integrationtest_) provides infrastructure that we use for developing and running automated integration and regression tests.  Part of what is provided is a set of functions that can be used to validate the DAQ data that is produced in such tests.  Many of these functions are contained in _data_file_checks.py_ (located in the _python/integrationtest_ subdirectory).
 
-Part of what is provided is a set of functions that can be used to validate the DAQ data that is produced in such tests.  Many of these functions are contained in _data_file_checks.py_ (located in the _python/integrationtest_ subdirectory).
+The functions that are provided in _data_file_checks._py have been written in a way that they can be used for different types of DAQ data (for example, TriggerRecords and TimeSlices, and/or WIBEth data and data fragments produced by the Trigger system).  The way that integtest developers specify the type of data that should be tested, and the success criteria that should be used, is by passing in a Python dictionary that contains specific values for a set of expected parameters.  
 
-The functions that are provided in data_file_checks.py have been written in a way that they can be used for different types of DAQ data (for example, TriggerRecords and TimeSlices, and/or WIBEth data and data fragments produced by the Trigger system).  The way that integtest developers specify the type of data that should be tested and the success criteria that should be used is by passing in a Python dictionary that contains specific values for a set of expected parameters.  Here is a sample:
+Here is a simple example:
+```
+wibeth_frag_params = {
+    "fragment_type_description": "WIBEth",
+    "fragment_type": "WIBEth",
+    "expected_fragment_count": (number_of_data_producers * number_of_readout_apps),
+    "min_size_bytes": 7272,
+    "max_size_bytes": 14472,
+    "debug_mask": 0x0,
+}
+```
 
-Here are the current set of supported parameters:
+Here is a more complicated sample:
+```
+wibeth_tpset_params = {
+    "fragment_type_description": "TP Stream",
+    "fragment_type": "Trigger_Primitive",
+    "expected_fragment_count": number_of_readout_apps * 3,
+    "frag_counts_by_record_ordinal": {"first": {"min_count": 1, "max_count": number_of_readout_apps * 3},
+                                      "default": {"min_count": number_of_readout_apps * 3, "max_count": number_of_readout_apps * 3} },
+    "min_size_bytes": 72,
+    "max_size_bytes": 300000,
+    "debug_mask": 0x0,
+    "frag_sizes_by_record_ordinal": {  "first": {"min_size_bytes":    128, "max_size_bytes": 275000},
+                                      "second": {"min_size_bytes":    128, "max_size_bytes": 275000},
+                                        "last": {"min_size_bytes":    128, "max_size_bytes": 275000},
+                                     "default": {"min_size_bytes": 190000, "max_size_bytes": 275000} }
+}
+```
 
+The current set of supported parameters is the following:
+
+- fragment_type - the value for this parameter needs to be a string that matches one of the defined ones in daqdataformats/FragmentHeader.hpp.
+- fragment_type_description - this is a short string that will be used to describe the fragment type in general terms in console output from the data-file-checks.
+- debug_mask - 

--- a/docs/DataFileCheckParameters.md
+++ b/docs/DataFileCheckParameters.md
@@ -1,0 +1,6 @@
+# integrationtest: Helpers for pytest-based DUNE DAQ integration tests
+
+Some of the data-file-check functions that are provided in this package (python/integrationtest/data_file_checks.py) expect a python dictionary with configuration parameters to be passed in.  These values for these parameters are specified in each of our automated integration and regression tests, and they can be used to fine-tune the data-quality tests that the data-file-check functions perform.
+
+Here are the current set of supported parameters within these configuration dictionaries:
+

--- a/docs/DataFileCheckParameters.md
+++ b/docs/DataFileCheckParameters.md
@@ -1,6 +1,10 @@
-# integrationtest: Helpers for pytest-based DUNE DAQ integration tests
+# Parameters that can be used to control data-file-check behavior
 
-Some of the data-file-check functions that are provided in this package (python/integrationtest/data_file_checks.py) expect a python dictionary with configuration parameters to be passed in.  These values for these parameters are specified in each of our automated integration and regression tests, and they can be used to fine-tune the data-quality tests that the data-file-check functions perform.
+This package (_integrationtest_) provides infrastructure that we use for developing and running automated integration and regression tests.
 
-Here are the current set of supported parameters within these configuration dictionaries:
+Part of what is provided is a set of functions that can be used to validate the DAQ data that is produced in such tests.  Many of these functions are contained in _data_file_checks.py_ (located in the _python/integrationtest_ subdirectory).
+
+The functions that are provided in data_file_checks.py have been written in a way that they can be used for different types of DAQ data (for example, TriggerRecords and TimeSlices, and/or WIBEth data and data fragments produced by the Trigger system).  The way that integtest developers specify the type of data that should be tested and the success criteria that should be used is by passing in a Python dictionary that contains specific values for a set of expected parameters.  Here is a sample:
+
+Here are the current set of supported parameters:
 

--- a/python/integrationtest/data_file_check_utilities.py
+++ b/python/integrationtest/data_file_check_utilities.py
@@ -1,0 +1,262 @@
+from hdf5libs import HDF5RawDataFile
+import daqdataformats
+import trgdataformats
+from num2words import num2words
+
+def get_TC_type(h5_file, record_id):
+    src_ids = h5_file.get_source_ids_for_fragment_type(record_id, 'Trigger_Candidate')
+    if len(src_ids) == 1:
+        for src_id in src_ids:
+            frag = h5_file.get_frag(record_id, src_id);
+            if frag.get_size() > 72:
+                tc = trgdataformats.TriggerCandidate(frag.get_data())
+                return trgdataformats.trigger_candidate_type_to_string(tc.data.type)
+    return "kUnknown"
+
+def get_record_ordinal_strings(record_id, full_record_list):
+    ordinal_strings = []
+    try:
+        index = full_record_list.index(record_id)
+        ordinal_strings.append(num2words(index+1, lang='en', to='ordinal'))
+        if index == (len(full_record_list)-1):
+            if len(ordinal_strings) >= 1 and index != 0:
+                ordinal_strings.insert(0, "last")
+            else:
+                ordinal_strings.append("last")
+        if len(full_record_list) > 1 and index == (len(full_record_list)-2):
+            if len(ordinal_strings) >= 1 and index >= 2:
+                ordinal_strings.insert(0, "penultimate")
+            else:
+                ordinal_strings.append("penultimate")
+    except:
+        pass
+    return ordinal_strings
+
+def get_fragment_count_limits(params, tc_type_string, record_ordinal_strings):
+    # set absurd initial values that will indicate a problem in what the user specified
+    min_count = 9999999
+    max_count = 0
+
+    # get first-level defaults from any top-level parameter specified by the user
+    if 'expected_fragment_count' in params.keys():
+        min_count = params['expected_fragment_count']
+        max_count = params['expected_fragment_count']
+
+    # check for counts that are specified by TC type
+    if 'frag_counts_by_TC_type' in params.keys():
+        tc_type_dict = params['frag_counts_by_TC_type']
+        if tc_type_string in tc_type_dict.keys():
+            count_dict = tc_type_dict[tc_type_string]
+            if 'min_count' in count_dict.keys():
+                min_count = count_dict['min_count']
+            if 'max_count' in count_dict.keys():
+                max_count = count_dict['max_count']
+        elif 'default' in tc_type_dict.keys():
+            count_dict = tc_type_dict['default']
+            if 'min_count' in count_dict.keys():
+                min_count = count_dict['min_count']
+            if 'max_count' in count_dict.keys():
+                max_count = count_dict['max_count']
+
+    # check for counts that are specified by record number
+    # (obviously, if both counts-by-TC-type and counts-by-record-ordinal are
+    # specfied, counts-by-record-ordinal wins because it is looked up last)
+    if 'frag_counts_by_record_ordinal' in params.keys() and len(record_ordinal_strings) > 0:
+        rno_string = record_ordinal_strings[0]
+        record_number_dict = params['frag_counts_by_record_ordinal']
+        if rno_string in record_number_dict.keys():
+            count_dict = record_number_dict[rno_string]
+            if 'min_count' in count_dict.keys():
+                min_count = count_dict['min_count']
+            if 'max_count' in count_dict.keys():
+                max_count = count_dict['max_count']
+        elif 'default' in record_number_dict.keys():
+            count_dict = record_number_dict['default']
+            if 'min_count' in count_dict.keys():
+                min_count = count_dict['min_count']
+            if 'max_count' in count_dict.keys():
+                max_count = count_dict['max_count']
+
+    return [min_count, max_count]
+
+def get_fragment_size_limits(params, tc_type_string, record_ordinal_strings):
+    # set absurd initial values that will indicate a problem in what the user specified
+    min_size = 9999999
+    max_size = 0
+
+    # get first-level defaults from any top-level parameters specified by the user
+    if 'min_size_bytes' in params.keys():
+        min_size = params['min_size_bytes']
+    if 'max_size_bytes' in params.keys():
+        max_size = params['max_size_bytes']
+
+    # check for sizes that are specified by TC type
+    if 'frag_sizes_by_TC_type' in params.keys():
+        tc_type_dict = params['frag_sizes_by_TC_type']
+        if tc_type_string in tc_type_dict.keys():
+            size_dict = tc_type_dict[tc_type_string]
+            if 'min_size_bytes' in size_dict.keys():
+                min_size = size_dict['min_size_bytes']
+            if 'max_size_bytes' in size_dict.keys():
+                max_size = size_dict['max_size_bytes']
+        elif 'default' in tc_type_dict.keys():
+            size_dict = tc_type_dict['default']
+            if 'min_size_bytes' in size_dict.keys():
+                min_size = size_dict['min_size_bytes']
+            if 'max_size_bytes' in size_dict.keys():
+                max_size = size_dict['max_size_bytes']
+
+    # check for sizes that are specified by record number
+    # (obviously, if both sizes-by-TC-type and sizes-by-record-ordinal are
+    # specfied, sizes-by-record-ordinal wins because it is looked up last)
+    if 'frag_sizes_by_record_ordinal' in params.keys() and len(record_ordinal_strings) > 0:
+        rno_string = record_ordinal_strings[0]
+        record_number_dict = params['frag_sizes_by_record_ordinal']
+        if rno_string in record_number_dict.keys():
+            size_dict = record_number_dict[rno_string]
+            if 'min_size_bytes' in size_dict.keys():
+                min_size = size_dict['min_size_bytes']
+            if 'max_size_bytes' in size_dict.keys():
+                max_size = size_dict['max_size_bytes']
+        elif 'default' in record_number_dict.keys():
+            size_dict = record_number_dict['default']
+            if 'min_size_bytes' in size_dict.keys():
+                min_size = size_dict['min_size_bytes']
+            if 'max_size_bytes' in size_dict.keys():
+                max_size = size_dict['max_size_bytes']
+
+    return [min_size, max_size]
+
+def record_ordinal_string_all_tests():
+    record_ordinal_string_test01()
+    record_ordinal_string_test02()
+    record_ordinal_string_test03()
+    record_ordinal_string_test04()
+    record_ordinal_string_test05()
+    record_ordinal_string_test06()
+    record_ordinal_string_test07()
+
+def record_ordinal_string_test01():
+    test_list = [999]
+    requested_value = 999
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 2 or ord_strings[0] != "first" or ord_strings[1] != "last":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value=requested_value ordinal_strings={ord_strings}')
+
+def record_ordinal_string_test02():
+    test_list = [888, 999]
+    requested_value = 888
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 2 or ord_strings[0] != "first" or ord_strings[1] != "penultimate":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 999
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 2 or ord_strings[0] != "last" or ord_strings[1] != "second":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+
+def record_ordinal_string_test03():
+    test_list = [777, 888, 999]
+    requested_value = 777
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 1 or ord_strings[0] != "first":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 888
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 2 or ord_strings[0] != "second" or ord_strings[1] != "penultimate":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 999
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 2 or ord_strings[0] != "last" or ord_strings[1] != "third":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+
+def record_ordinal_string_test04():
+    test_list = [666, 777, 888, 999]
+    requested_value = 666
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 1 or ord_strings[0] != "first":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 777
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 1 or ord_strings[0] != "second":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 888
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 2 or ord_strings[0] != "penultimate" or ord_strings[1] != "third":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 999
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 2 or ord_strings[0] != "last" or ord_strings[1] != "fourth":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+
+def record_ordinal_string_test05():
+    test_list = [555, 666, 777, 888, 999]
+    requested_value = 555
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 1 or ord_strings[0] != "first":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 666
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 1 or ord_strings[0] != "second":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 777
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 1 or ord_strings[0] != "third":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 888
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 2 or ord_strings[0] != "penultimate" or ord_strings[1] != "fourth":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 999
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 2 or ord_strings[0] != "last" or ord_strings[1] != "fifth":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+
+def record_ordinal_string_test06():
+    test_list = [111, 222, 333, 444, 555, 666, 777, 888, 999]
+    requested_value = 111
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 1 or ord_strings[0] != "first":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 222
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 1 or ord_strings[0] != "second":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 333
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 1 or ord_strings[0] != "third":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 444
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 1 or ord_strings[0] != "fourth":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 555
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 1 or ord_strings[0] != "fifth":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 666
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 1 or ord_strings[0] != "sixth":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 777
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 1 or ord_strings[0] != "seventh":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 888
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 2 or ord_strings[0] != "penultimate" or ord_strings[1] != "eighth":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 999
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 2 or ord_strings[0] != "last" or ord_strings[1] != "ninth":
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+
+def record_ordinal_string_test07():
+    test_list = [111, 222, 333, 444, 555, 666, 777, 888, 999]
+    requested_value = 123
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 0:
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')
+    requested_value = 9999
+    ord_strings = get_record_ordinal_strings(requested_value, test_list)
+    if len(ord_strings) != 0:
+        print(f'\N{POLICE CARS REVOLVING LIGHT} UNIT TEST FAILURE: test_list={test_list} value={requested_value} ordinal_strings={ord_strings}')

--- a/python/integrationtest/data_file_checks.py
+++ b/python/integrationtest/data_file_checks.py
@@ -44,10 +44,10 @@ def sanity_check(datafile):
             if "TriggerRecordHeader" in key:
                 triggerrecordheader_count += 1
         if triggerrecordheader_count == 0:
-            print(f"\N{POLICE CARS REVOLVING LIGHT} No TriggerRecordHeader in event {event} \N{POLICE CARS REVOLVING LIGHT}")
+            print(f"\N{POLICE CARS REVOLVING LIGHT} No TriggerRecordHeader in record {event} \N{POLICE CARS REVOLVING LIGHT}")
             passed=False
         if triggerrecordheader_count > 1:
-            print(f"\N{POLICE CARS REVOLVING LIGHT} More than one TriggerRecordHeader in event {event} \N{POLICE CARS REVOLVING LIGHT}")
+            print(f"\N{POLICE CARS REVOLVING LIGHT} More than one TriggerRecordHeader in record {event} \N{POLICE CARS REVOLVING LIGHT}")
             passed=False
     if passed:
         print("\N{WHITE HEAVY CHECK MARK} Sanity-check passed")
@@ -104,16 +104,16 @@ def check_file_attributes(datafile):
     return passed
 
 def check_event_count(datafile, expected_value, tolerance):
-    "Check that the number of events is within tolerance of expected_value"
+    "Check that the number of records in the file is within tolerance of the expected_value"
     passed=True
     event_count=len(datafile.events)
     min_event_count=expected_value-tolerance
     max_event_count=expected_value+tolerance
     if event_count<min_event_count or event_count>max_event_count:
         passed=False
-        print(f"\N{POLICE CARS REVOLVING LIGHT} Event count {event_count} is outside the tolerance of {tolerance} from an expected value of {expected_value} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\N{POLICE CARS REVOLVING LIGHT} Record count {event_count} is outside the tolerance of {tolerance} from an expected value of {expected_value} \N{POLICE CARS REVOLVING LIGHT}")
     if passed:
-        print(f"\N{WHITE HEAVY CHECK MARK} Event count {event_count} is within a tolerance of {tolerance} from an expected value of {expected_value}")
+        print(f"\N{WHITE HEAVY CHECK MARK} Record count {event_count} is within a tolerance of {tolerance} from an expected value of {expected_value}")
     return passed
 
 # 18-Aug-2021, KAB: General-purposed test for fragment count.  The idea behind this test
@@ -129,7 +129,7 @@ def check_event_count(datafile, expected_value, tolerance):
 #                         e.g. "Detector_Readout" or "Trigger"
 # * expected_fragment_count - the expected number of fragments of this type
 def check_fragment_count(datafile, params):
-    "Checking that there are {params['expected_fragment_count']} {params['fragment_type_description']} fragments in each event in file"
+    "Checking that there are {params['expected_fragment_count']} {params['fragment_type_description']} fragments in each record in the file"
     passed=True
     for event in datafile.events:
         frag_list = find_fragments_of_specified_type(datafile.h5file[event], params['hdf5_source_subsystem'],
@@ -137,9 +137,9 @@ def check_fragment_count(datafile, params):
         fragment_count=len(frag_list)
         if fragment_count != params['expected_fragment_count']:
             passed=False
-            print(f"\N{POLICE CARS REVOLVING LIGHT} Event {event} has an unexpected number of {params['fragment_type_description']} fragments: {fragment_count} (expected {params['expected_fragment_count']}) \N{POLICE CARS REVOLVING LIGHT}")
+            print(f"\N{POLICE CARS REVOLVING LIGHT} Record {event} has an unexpected number of {params['fragment_type_description']} fragments: {fragment_count} (expected {params['expected_fragment_count']}) \N{POLICE CARS REVOLVING LIGHT}")
     if passed:
-        print(f"\N{WHITE HEAVY CHECK MARK} {params['fragment_type_description']} fragment count of {params['expected_fragment_count']} confirmed in all {datafile.n_events} events")
+        print(f"\N{WHITE HEAVY CHECK MARK} {params['fragment_type_description']} fragment count of {params['expected_fragment_count']} confirmed in all {datafile.n_events} records")
     return passed
 
 # 18-Aug-2021, KAB: general-purposed test for fragment sizes.  The idea behind this test
@@ -168,9 +168,9 @@ def check_fragment_sizes(datafile, params):
             size=frag.shape[0]
             if size<params['min_size_bytes'] or size>params['max_size_bytes']:
                 passed=False
-                print(f" \N{POLICE CARS REVOLVING LIGHT} {params['fragment_type_description']} fragment {frag.name} in event {event} has size {size}, outside range [{params['min_size_bytes']}, {params['max_size_bytes']}] \N{POLICE CARS REVOLVING LIGHT}")
+                print(f" \N{POLICE CARS REVOLVING LIGHT} {params['fragment_type_description']} fragment {frag.name} in record {event} has size {size}, outside range [{params['min_size_bytes']}, {params['max_size_bytes']}] \N{POLICE CARS REVOLVING LIGHT}")
     if passed:
-        print(f"\N{WHITE HEAVY CHECK MARK} All {params['fragment_type_description']} fragments in {datafile.n_events} events have sizes between {params['min_size_bytes']} and {params['max_size_bytes']}")
+        print(f"\N{WHITE HEAVY CHECK MARK} All {params['fragment_type_description']} fragments in {datafile.n_events} records have sizes between {params['min_size_bytes']} and {params['max_size_bytes']}")
     return passed
 
 

--- a/python/integrationtest/data_file_checks.py
+++ b/python/integrationtest/data_file_checks.py
@@ -166,11 +166,13 @@ def check_fragment_sizes(datafile, params):
 
     "Checking that every {params['fragment_type_description']} fragment size is between {params['min_size_bytes']} and {params['max_size_bytes']}"
     passed=True
-    for event in datafile.events:
-        frag_list = find_fragments_of_specified_type(datafile.h5file[event], params['hdf5_source_subsystem'],
-                                                     params['fragment_type']);
-        for frag in frag_list:
-            size=frag.shape[0]
+    h5_file = HDF5RawDataFile(datafile.name)
+    records = h5_file.get_all_record_ids()
+    for rec in records:
+        src_ids = h5_file.get_source_ids_for_fragment_type(rec, params['fragment_type'])
+        for src_id in src_ids:
+            frag=h5_file.get_frag(rec,src_id);
+            size=frag.get_size()
             if size<params['min_size_bytes'] or size>params['max_size_bytes']:
                 passed=False
                 print(f" \N{POLICE CARS REVOLVING LIGHT} {params['fragment_type_description']} fragment {frag.name} in record {event} has size {size}, outside range [{params['min_size_bytes']}, {params['max_size_bytes']}] \N{POLICE CARS REVOLVING LIGHT}")

--- a/python/integrationtest/data_file_checks.py
+++ b/python/integrationtest/data_file_checks.py
@@ -110,14 +110,12 @@ def check_event_count(datafile, expected_value, tolerance):
 # 18-Aug-2021, KAB: General-purposed test for fragment count.  The idea behind this test
 # is that each type of fragment can be tested individually, by calling this routine for
 # each type.  The test is driven by a set of parameters that describe both the fragments
-# to be tested (e.g. the HDF5 Group names) and the characteristics that they should have
+# to be tested (e.g. the Fragment type) and the characteristics that they should have
 # (e.g. the number of fragments that should be present).
 #
 # The parameters that are required by this routine are the following:
 # * fragment_type_description - descriptive text for the fragment type, e.g. "WIB" or "PDS" or "Raw TP"
 # * fragment_type - Type of the Fragment, e.g. "ProtoWIB" or "Trigger_Primitive"
-# * hdf5_source_subsystem - the Subsystem of the Fragments to find,
-#                         e.g. "Detector_Readout" or "Trigger"
 # * expected_fragment_count - the expected number of fragments of this type
 def check_fragment_count(datafile, params):
     debug_mask = 0
@@ -165,14 +163,12 @@ def check_fragment_count(datafile, params):
 # 18-Aug-2021, KAB: general-purposed test for fragment sizes.  The idea behind this test
 # is that each type of fragment can be tested individually, by calling this routine for
 # each type.  The test is driven by a set of parameters that describe both the fragments
-# to be tested (e.g. the HDF5 Group names) and the characteristics that they should have
+# to be tested (e.g. the Fragment type) and the characteristics that they should have
 # (e.g. the minimum and maximum fragment size).
 #
 # The parameters that are required by this routine are the following:
 # * fragment_type_description - descriptive text for the fragment type, e.g. "WIB" or "PDS" or "Raw TP"
 # * fragment_type - Type of the Fragment, e.g. "ProtoWIB" or "Trigger_Primitive"
-# * hdf5_source_subsystem - the Subsystem of the Fragments to find,
-#                         e.g. "Detector_Readout" or "Trigger"
 # * min_size_bytes - the minimum size of fragments of this type
 # * max_size_bytes - the maximum size of fragments of this type
 def check_fragment_sizes(datafile, params):

--- a/python/integrationtest/data_file_checks.py
+++ b/python/integrationtest/data_file_checks.py
@@ -125,6 +125,9 @@ def check_fragment_count(datafile, params):
         debug_mask = params['debug_mask']
     min_count_list = []
     max_count_list = []
+    subdet_string = ""
+    if 'subdetector' in params:
+        subdet_string = params['subdetector']
 
     "Checking that there are {params['expected_fragment_count']} {params['fragment_type_description']} fragments in each record in the file"
     passed=True
@@ -140,7 +143,10 @@ def check_fragment_count(datafile, params):
             min_count_list.append(fragment_count_limits[0])
         if fragment_count_limits[1] not in max_count_list:
             max_count_list.append(fragment_count_limits[1])
-        src_ids = h5_file.get_source_ids_for_fragment_type(rec, params['fragment_type'])
+        if subdet_string == "":
+            src_ids = h5_file.get_source_ids_for_fragment_type(rec, params['fragment_type'])
+        else:
+            src_ids = h5_file.get_source_ids_for_fragtype_and_subdetector(rec, params['fragment_type'], subdet_string)
         fragment_count=len(src_ids)
         if (debug_mask & 0x2) != 0:
             print(f'  DataFileChecks Debug: fragment count is {fragment_count}')
@@ -177,6 +183,9 @@ def check_fragment_sizes(datafile, params):
         debug_mask = params['debug_mask']
     min_size_list = []
     max_size_list = []
+    subdet_string = ""
+    if 'subdetector' in params:
+        subdet_string = params['subdetector']
 
     "Checking that every {params['fragment_type_description']} fragment size is within its allowed range"
     passed=True
@@ -192,7 +201,10 @@ def check_fragment_sizes(datafile, params):
             min_size_list.append(size_limits[0])
         if size_limits[1] not in max_size_list:
             max_size_list.append(size_limits[1])
-        src_ids = h5_file.get_source_ids_for_fragment_type(rec, params['fragment_type'])
+        if subdet_string == "":
+            src_ids = h5_file.get_source_ids_for_fragment_type(rec, params['fragment_type'])
+        else:
+            src_ids = h5_file.get_source_ids_for_fragtype_and_subdetector(rec, params['fragment_type'], subdet_string)
         for src_id in src_ids:
             frag=h5_file.get_frag(rec,src_id);
             size=frag.get_size()

--- a/python/integrationtest/data_file_checks.py
+++ b/python/integrationtest/data_file_checks.py
@@ -3,8 +3,13 @@ import h5py
 import os.path
 import re
 from hdf5libs import HDF5RawDataFile
-import daqdataformats
-import trgdataformats
+from integrationtest.data_file_check_utilities import (
+    get_TC_type,
+    get_record_ordinal_strings,
+    get_fragment_count_limits,
+    get_fragment_size_limits,
+    record_ordinal_string_all_tests,
+)
 
 class DataFile:
     def __init__(self, filename):
@@ -12,61 +17,15 @@ class DataFile:
         self.events=self.h5file.keys()
         self.name=str(filename)
 
-def get_TC_type(h5_file, record_id):
-    src_ids = h5_file.get_source_ids_for_fragment_type(record_id, 'Trigger_Candidate')
-    for src_id in src_ids:
-        frag = h5_file.get_frag(record_id, src_id);
-        tc = trgdataformats.TriggerCandidate(frag.get_data())
-        print(f'{src_id} {frag.get_fragment_type()} {tc.data.type}')
-
-def get_size_envelope(params):
-    min_size = 0
-    max_size = 0
-    sizes_are_from_envelope = False
-    if 'frag_sizes_by_TC_type' in params.keys():
-#        print("AAA")
-        tc_type_dict = params['frag_sizes_by_TC_type']
-        sizes_are_from_envelope = len(tc_type_dict) > 1
-        min_size = 999999
-        for tc_type in tc_type_dict.keys():
-            size_dict = tc_type_dict[tc_type]
-            if 'min_size_bytes' in size_dict.keys() and size_dict['min_size_bytes'] < min_size:
-                min_size = size_dict['min_size_bytes']
-            if 'max_size_bytes' in size_dict.keys() and size_dict['max_size_bytes'] > max_size:
-                max_size = size_dict['max_size_bytes']
-    else:
-#        print("BBB")
-        if 'min_size_bytes' in params.keys():
-            min_size = params['min_size_bytes']
-        if 'max_size_bytes' in params.keys():
-            max_size = params['max_size_bytes']
-    return [min_size, max_size, sizes_are_from_envelope]
-
-def get_size_limits(h5_file, record_id, params):
-    min_size = 0
-    max_size = 0
-    if 'frag_sizes_by_TC_type' in params.keys():
-#        print("CCC")
-        get_TC_type(h5_file, record_id)
-        tc_type_dict = params['frag_sizes_by_TC_type']
-        if 'default' in tc_type_dict.keys():
-            size_dict = tc_type_dict['default']
-            if 'min_size_bytes' in size_dict.keys():
-                min_size = size_dict['min_size_bytes']
-            if 'max_size_bytes' in size_dict.keys():
-                max_size = size_dict['max_size_bytes']
-    else:
-#        print("DDD")
-        if 'min_size_bytes' in params.keys():
-            min_size = params['min_size_bytes']
-        if 'max_size_bytes' in params.keys():
-            max_size = params['max_size_bytes']
-    return [min_size, max_size]
-
 def sanity_check(datafile):
     "Very basic sanity checks on file"
     passed=True
     print("") # Clear potential dot from pytest
+
+    # execute unit tests for local function(s)
+    # (this is probably not the best place for these...)
+    record_ordinal_string_all_tests()
+
     # Check that every event has a TriggerRecordHeader
     for event in datafile.events:
         triggerrecordheader_count = 0
@@ -87,6 +46,8 @@ def check_file_attributes(datafile):
     "Checking that the expected Attributes exist within the data file"
     passed=True
     base_filename = os.path.basename(datafile.h5file.filename)
+    if "tp" in base_filename:
+        print("") # Clear potential dot from pytest
     expected_attribute_names = ["application_name", "closing_timestamp", "creation_timestamp", "file_index", "filelayout_params", "filelayout_version", "offline_data_stream", "operational_environment", "record_type", "recorded_size", "run_number", "run_was_for_test_purposes", "source_id_geo_id_map"]
     for expected_attr_name in expected_attribute_names:
         if expected_attr_name not in datafile.h5file.attrs.keys():
@@ -159,18 +120,40 @@ def check_event_count(datafile, expected_value, tolerance):
 #                         e.g. "Detector_Readout" or "Trigger"
 # * expected_fragment_count - the expected number of fragments of this type
 def check_fragment_count(datafile, params):
+    debug_mask = 0
+    if 'debug_mask' in params:
+        debug_mask = params['debug_mask']
+    min_count_list = []
+    max_count_list = []
+
     "Checking that there are {params['expected_fragment_count']} {params['fragment_type_description']} fragments in each record in the file"
     passed=True
     h5_file = HDF5RawDataFile(datafile.name)
     records = h5_file.get_all_record_ids()
     for rec in records:
+        tc_type_string = get_TC_type(h5_file, rec)
+        rno_strings = get_record_ordinal_strings(rec, records)
+        fragment_count_limits = get_fragment_count_limits(params, tc_type_string, rno_strings)
+        if (debug_mask & 0x1) != 0:
+            print(f'DataFileChecks Debug: the fragment count limits are {fragment_count_limits} for TC type {tc_type_string} and record ordinal strings {rno_strings}')
+        if fragment_count_limits[0] not in min_count_list:
+            min_count_list.append(fragment_count_limits[0])
+        if fragment_count_limits[1] not in max_count_list:
+            max_count_list.append(fragment_count_limits[1])
         src_ids = h5_file.get_source_ids_for_fragment_type(rec, params['fragment_type'])
         fragment_count=len(src_ids)
-        if fragment_count != params['expected_fragment_count']:
+        if (debug_mask & 0x2) != 0:
+            print(f'  DataFileChecks Debug: fragment count is {fragment_count}')
+        if fragment_count<fragment_count_limits[0] or fragment_count>fragment_count_limits[1]:
             passed=False
-            print(f"\N{POLICE CARS REVOLVING LIGHT} Record {rec} has an unexpected number of {params['fragment_type_description']} fragments: {fragment_count} (expected {params['expected_fragment_count']}) \N{POLICE CARS REVOLVING LIGHT}")
+            print(f"\N{POLICE CARS REVOLVING LIGHT} Record {rec} has an unexpected number of {params['fragment_type_description']} fragments: {fragment_count} (outside range {fragment_count_limits}) \N{POLICE CARS REVOLVING LIGHT}")
     if passed:
-        print(f"\N{WHITE HEAVY CHECK MARK} {params['fragment_type_description']} fragment count of {params['expected_fragment_count']} confirmed in all {len(records)} records")
+        min_count_list.sort()
+        max_count_list.sort()
+        if len(min_count_list) > 1 or len(max_count_list) > 1 or min_count_list[0] != max_count_list[0]:
+            print(f"\N{WHITE HEAVY CHECK MARK} {params['fragment_type_description']} fragment count in range {min_count_list} to {max_count_list} confirmed in all {len(records)} records")
+        else:
+            print(f"\N{WHITE HEAVY CHECK MARK} {params['fragment_type_description']} fragment count of {min_count_list[0]} confirmed in all {len(records)} records")
     return passed
 
 # 18-Aug-2021, KAB: general-purposed test for fragment sizes.  The idea behind this test
@@ -189,25 +172,37 @@ def check_fragment_count(datafile, params):
 def check_fragment_sizes(datafile, params):
     if params['expected_fragment_count'] == 0:
         return True
+    debug_mask = 0
+    if 'debug_mask' in params:
+        debug_mask = params['debug_mask']
+    min_size_list = []
+    max_size_list = []
 
     "Checking that every {params['fragment_type_description']} fragment size is within its allowed range"
     passed=True
     h5_file = HDF5RawDataFile(datafile.name)
     records = h5_file.get_all_record_ids()
     for rec in records:
-        size_limits = get_size_limits(h5_file, rec, params)
+        tc_type_string = get_TC_type(h5_file, rec)
+        rno_strings = get_record_ordinal_strings(rec, records)
+        size_limits = get_fragment_size_limits(params, tc_type_string, rno_strings)
+        if (debug_mask & 0x4) != 0:
+            print(f'DataFileChecks Debug: the fragment size limits are {size_limits} for TC type {tc_type_string} and record ordinal strings {rno_strings}')
+        if size_limits[0] not in min_size_list:
+            min_size_list.append(size_limits[0])
+        if size_limits[1] not in max_size_list:
+            max_size_list.append(size_limits[1])
         src_ids = h5_file.get_source_ids_for_fragment_type(rec, params['fragment_type'])
         for src_id in src_ids:
             frag=h5_file.get_frag(rec,src_id);
             size=frag.get_size()
+            if (debug_mask & 0x8) != 0:
+                print(f'  DataFileChecks Debug: fragment size for SourceID {src_id} is {size}')
             if size<size_limits[0] or size>size_limits[1]:
                 passed=False
-                print(f" \N{POLICE CARS REVOLVING LIGHT} {params['fragment_type_description']} fragment for SrcID {src_id.to_string()} in record {rec} has size {size}, outside range [{size_limits[0]}, {size_limits[1]}] \N{POLICE CARS REVOLVING LIGHT}")
+                print(f" \N{POLICE CARS REVOLVING LIGHT} {params['fragment_type_description']} fragment for SrcID {src_id.to_string()} in record {rec} has size {size} (outside range {size_limits}) \N{POLICE CARS REVOLVING LIGHT}")
     if passed:
-        size_limit_envelope = get_size_envelope(params)
-        sizes_are_from_envelope = size_limit_envelope[2]
-        if sizes_are_from_envelope:
-            print(f"\N{WHITE HEAVY CHECK MARK} All {params['fragment_type_description']} fragments in {len(records)} records have the expected sizes, between {size_limit_envelope[0]} and {size_limit_envelope[1]} for all TC types")
-        else:
-            print(f"\N{WHITE HEAVY CHECK MARK} All {params['fragment_type_description']} fragments in {len(records)} records have sizes between {size_limit_envelope[0]} and {size_limit_envelope[1]}")
+        min_size_list.sort()
+        max_size_list.sort()
+        print(f"\N{WHITE HEAVY CHECK MARK} All {params['fragment_type_description']} fragments in {len(records)} records have sizes between {min_size_list[0] if len(min_size_list) == 1 else min_size_list} and {max_size_list[0] if len(max_size_list) == 1 else max_size_list}")
     return passed

--- a/python/integrationtest/data_file_checks.py
+++ b/python/integrationtest/data_file_checks.py
@@ -58,7 +58,7 @@ def sanity_check(datafile):
     return passed
 
 def check_file_attributes(datafile):
-    "Check that the expected Attributes exist within the data file"
+    "Checking that the expected Attributes exist within the data file"
     passed=True
     base_filename = os.path.basename(datafile.h5file.filename)
     expected_attribute_names = ["application_name", "closing_timestamp", "creation_timestamp", "file_index", "filelayout_params", "filelayout_version", "offline_data_stream", "operational_environment", "record_type", "recorded_size", "run_number", "run_was_for_test_purposes", "source_id_geo_id_map"]
@@ -108,7 +108,7 @@ def check_file_attributes(datafile):
     return passed
 
 def check_event_count(datafile, expected_value, tolerance):
-    "Check that the number of records in the file is within tolerance of the expected_value"
+    "Checking that the number of records in the file is within tolerance of the expected_value"
     passed=True
     event_count=len(datafile.events)
     min_event_count=expected_value-tolerance
@@ -164,7 +164,7 @@ def check_fragment_sizes(datafile, params):
     if params['expected_fragment_count'] == 0:
         return True
 
-    "Check that every {params['fragment_type_description']} fragment size is between {params['min_size_bytes']} and {params['max_size_bytes']}"
+    "Checking that every {params['fragment_type_description']} fragment size is between {params['min_size_bytes']} and {params['max_size_bytes']}"
     passed=True
     for event in datafile.events:
         frag_list = find_fragments_of_specified_type(datafile.h5file[event], params['hdf5_source_subsystem'],

--- a/python/integrationtest/data_file_checks.py
+++ b/python/integrationtest/data_file_checks.py
@@ -10,37 +10,12 @@ class DataFile:
     def __init__(self, filename):
         self.h5file=h5py.File(filename, 'r')
         self.events=self.h5file.keys()
-        self.n_events=len(self.events)
         self.name=str(filename)
-
-def find_fragments_of_specified_type(grp, subsystem='', fragment_type=''):
-    frag_list = [] # Local variable here
-    def visitor(name, obj):
-        nonlocal frag_list  # non-local to the visitor function
-        pattern = ".*"
-        if subsystem != '':
-            pattern = f'.*/{subsystem}_0x[0-9a-fA-F]+_'
-        if fragment_type != '':
-            pattern += f'{fragment_type}'
-        else:
-            pattern += ".*"
-        if isinstance(obj, h5py.Dataset):
-            #print(f"checking {obj.name} against pattern {pattern}")
-            if re.match(pattern, obj.name):
-                frag_list.append(obj)
-    grp["RawData"].visititems(visitor)
-    #print(f"find_fragments_of_specified_type returning {len(frag_list)} fragments")
-    return frag_list
 
 def sanity_check(datafile):
     "Very basic sanity checks on file"
     passed=True
     print("") # Clear potential dot from pytest
-    # Check that we didn't miss any events (sort of)
-    #
-    # This condition isn't true if there are multiple files for this
-    # run, and this file isn't the first one, so don't do it
-    # assert list(datafile.events)[-1] == ("TriggerRecord%05d" % datafile.n_events)
     # Check that every event has a TriggerRecordHeader
     for event in datafile.events:
         triggerrecordheader_count = 0
@@ -144,7 +119,7 @@ def check_fragment_count(datafile, params):
             passed=False
             print(f"\N{POLICE CARS REVOLVING LIGHT} Record {event} has an unexpected number of {params['fragment_type_description']} fragments: {fragment_count} (expected {params['expected_fragment_count']}) \N{POLICE CARS REVOLVING LIGHT}")
     if passed:
-        print(f"\N{WHITE HEAVY CHECK MARK} {params['fragment_type_description']} fragment count of {params['expected_fragment_count']} confirmed in all {datafile.n_events} records")
+        print(f"\N{WHITE HEAVY CHECK MARK} {params['fragment_type_description']} fragment count of {params['expected_fragment_count']} confirmed in all {len(records)} records")
     return passed
 
 # 18-Aug-2021, KAB: general-purposed test for fragment sizes.  The idea behind this test
@@ -177,25 +152,5 @@ def check_fragment_sizes(datafile, params):
                 passed=False
                 print(f" \N{POLICE CARS REVOLVING LIGHT} {params['fragment_type_description']} fragment {frag.name} in record {event} has size {size}, outside range [{params['min_size_bytes']}, {params['max_size_bytes']}] \N{POLICE CARS REVOLVING LIGHT}")
     if passed:
-        print(f"\N{WHITE HEAVY CHECK MARK} All {params['fragment_type_description']} fragments in {datafile.n_events} records have sizes between {params['min_size_bytes']} and {params['max_size_bytes']}")
-    return passed
-
-
-# ###########################################################################
-# 11-Nov-2021, KAB: the following routines are deprecated.
-# Please do not use them. If one of the routines defined above does not meet
-# a need, let's talk about how to meet that need without using one of the
-# routines defined below.
-# ###########################################################################
-
-def check_link_presence(datafile, n_links):
-    "Check that there are n_links links in each event in file"
-    passed=False
-    print("\N{POLICE CARS REVOLVING LIGHT} The check_link_presence test has been deprecated. Please use check_fragment_count instead. \N{POLICE CARS REVOLVING LIGHT}")
-    return passed
-
-def check_fragment_presence(datafile, params):
-    "Checking that there are the expected fragments in each event in file"
-    passed=False
-    print("\N{POLICE CARS REVOLVING LIGHT} The check_fragment_presence test has been deprecated. Please use check_fragment_count instead. \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\N{WHITE HEAVY CHECK MARK} All {params['fragment_type_description']} fragments in {len(records)} records have sizes between {params['min_size_bytes']} and {params['max_size_bytes']}")
     return passed


### PR DESCRIPTION
The primary (externally-observable) changes are the addition of support for specifying different expected fragment count and expected fragment size values for records with different TriggerCandidate types and different locations in the raw data files.

A big internal change was the switch from using HDF5 Group and DataSet names to fetch data fragments to using tools provided in hdf5libs.

The changes are backward compatible, in terms of the parameters that we currently specify in our integtests (e.g. daqsystemtest/integtest).  However, they depend on changes in the hdf5libs package ([PR 111](https://github.com/DUNE-DAQ/hdf5libs/pull/111)), so they should be tested and merged in conjunction with those.

There is a new markdown document in the "docs" subdirectory that describes a little about the currently-supported parameters for the check_fragment_count() and check_fragment_sizes() functions.