### PR TITLE
An attempt to fix the dataclass usage in Python 3.11 

### DIFF
--- a/python/integrationtest/data_classes.py
+++ b/python/integrationtest/data_classes.py
@@ -22,7 +22,7 @@ class config_substitution:
 class drunc_config:
     op_env: str = "integtest"
     session: str = "integtest"
-    dro_map_config: DROMap_config = DROMap_config(1)
+    dro_map_config: DROMap_config = field(default_factory=lambda: DROMap_config(1))
     frame_file: str = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e"
     tpg_enabled: bool = False
     fake_hsi_enabled: bool = False


### PR DESCRIPTION
https://docs.python.org/3/library/dataclasses.html#mutable-default-values

Resolves #97 

Tested to be backwards-compatible with current Python