### PR TITLE
Modified the extension used for the ConnSvc logfile from .log to .txt…

### DIFF
--- a/python/integrationtest/integrationtest_drunc.py
+++ b/python/integrationtest/integrationtest_drunc.py
@@ -274,7 +274,7 @@ def run_nanorc(request, create_config_files, tmp_path_factory):
 
         connsvc_log = open(
             run_dir
-            / f"log_{getpass.getuser()}_{create_config_files.config.session}_connectivity-service.log",
+            / f"log_{getpass.getuser()}_{create_config_files.config.session}_connectivity-service.txt",
             "w",
         )
         connsvc_obj = subprocess.Popen(
@@ -366,7 +366,9 @@ def run_nanorc(request, create_config_files, tmp_path_factory):
     )
 
     if connsvc_obj is not None:
+        time.sleep(1)
         connsvc_obj.send_signal(2)
+        time.sleep(0.5)
         connsvc_obj.kill()
 
     if create_config_files.config.attempt_cleanup:

--- a/python/integrationtest/integrationtest_drunc.py
+++ b/python/integrationtest/integrationtest_drunc.py
@@ -368,7 +368,10 @@ def run_nanorc(request, create_config_files, tmp_path_factory):
     if connsvc_obj is not None:
         time.sleep(1)
         connsvc_obj.send_signal(2)
-        time.sleep(0.5)
+        try:
+            connsvc_obj.wait(0.5)
+        except:
+            pass
         connsvc_obj.kill()
 
     if create_config_files.config.attempt_cleanup:


### PR DESCRIPTION
… (to match other logfiles); added small sleep before ConnSvc kills to try to avoid connection problems from DAQ Apps as they shut down.

These are minor changes that were motivated by recent debugging of automated regression tests...

- it is convenient to search all regression test log files by using 'grep <string> log*.txt', and this wasn't possible without the ConnSvc log file rename
- in a small number of the overnight regression test runs, I noticed a 'connection failure' message in one of the DAQ or controller app log files at the end of the DAQ session.  I haven't been able to find the exact cause of those messages, but I did verify that the regression test(s) in question use the integrationtest infrastructure for starting and stopping the ConnectivityService.  So, I thought that we could try a little bit of sleep before the ConnSvc shutdown and see if that helps.