### PR TITLE
Add an option to specify the session name (same as config_id)

### DIFF
--- a/python/integrationtest/integrationtest_drunc.py
+++ b/python/integrationtest/integrationtest_drunc.py
@@ -358,6 +358,7 @@ def run_nanorc(request, create_config_files, tmp_path_factory):
     result.completed_process = subprocess.run(
         [nanorc]
         + nanorc_option_strings
+        + ["-s" + str(create_config_files.config.session)]
         + [str("ssh-standalone")]
         + [str(create_config_files.config_file)]
         + [str(create_config_files.config.session)]

--- a/python/integrationtest/integrationtest_drunc.py
+++ b/python/integrationtest/integrationtest_drunc.py
@@ -358,9 +358,9 @@ def run_nanorc(request, create_config_files, tmp_path_factory):
     result.completed_process = subprocess.run(
         [nanorc]
         + nanorc_option_strings
-        + ["-s" + str(create_config_files.config.session)]
         + [str("ssh-standalone")]
         + [str(create_config_files.config_file)]
+        + [str(create_config_files.config.session)]
         + [str(create_config_files.config.session)]
         + command_list,
         cwd=run_dir,


### PR DESCRIPTION
To be used with https://github.com/DUNE-DAQ/drunc/pull/387, to get the integ test to pass.