### PR TITLE
added the flushing of print statements to data_file and log_file checks…

### DIFF
--- a/python/integrationtest/data_file_checks.py
+++ b/python/integrationtest/data_file_checks.py
@@ -13,6 +13,10 @@ from integrationtest.data_file_check_utilities import (
     record_ordinal_string_all_tests,
 )
 
+# 21-May-2025, KAB: tweak the print() statement default behavior so that it always flushes the output.
+import functools
+print = functools.partial(print, flush=True)
+
 class DataFile:
     def __init__(self, filename):
         self.h5file=h5py.File(filename, 'r')

--- a/python/integrationtest/log_file_checks.py
+++ b/python/integrationtest/log_file_checks.py
@@ -1,6 +1,10 @@
 from glob import glob
 import re
 
+# 21-May-2025, KAB: tweak the print() statement default behavior so that it always flushes the output.
+import functools
+print = functools.partial(print, flush=True)
+
 def log_has_no_errors(log_file_name, print_logfilename_for_problems=True, excluded_substring_list=[], required_substring_list=[], print_required_message_report=False):
     ok=True
     ignored_problem_count=0


### PR DESCRIPTION
…to provide more responsive feedback to users.

While working on the new `hdf5_compression_test` in the `dfmodules` repo, I noticed that the console output from the data file checks was not appearing as it was generated, but rather it was all appearing in a burst after all of the checks had finished.

These changes flush the `print()` statement output so that the results are visible sooner.

To test this, I locally-modified a copy of the `tpstream_writer_test.py` in the `daqsystemtest` repo to sleep for a second between each data-file check.  Without these changes, the data-file check print statements were all printed out in a burst at the end of the checking.  With these changes, they were output more smoothly.