### PR TITLE
Session name and connectivity service noop

### DIFF
--- a/python/integrationtest/data_classes.py
+++ b/python/integrationtest/data_classes.py
@@ -22,6 +22,7 @@ class config_substitution:
 class drunc_config:
     op_env: str = "integtest"
     session: str = "integtest"
+    session_name: str = None
     dro_map_config: DROMap_config = field(default_factory=lambda: DROMap_config(1))
     frame_file: str = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e"
     tpg_enabled: bool = False

--- a/python/integrationtest/integrationtest_drunc.py
+++ b/python/integrationtest/integrationtest_drunc.py
@@ -361,7 +361,7 @@ def run_nanorc(request, create_config_files, tmp_path_factory):
         + [str("ssh-standalone")]
         + [str(create_config_files.config_file)]
         + [str(create_config_files.config.session)]
-        + [str(create_config_files.config.session)]
+        + [str(create_config_files.config.session_name if create_config_files.config.session_name else create_config_files.config.session)]
         + command_list,
         cwd=run_dir,
     )
@@ -383,6 +383,7 @@ def run_nanorc(request, create_config_files, tmp_path_factory):
 
     result.confgen_config = create_config_files.config
     result.session = create_config_files.config.session
+    result.session_name = create_config_files.config.session_name
     result.nanorc_commands = command_list
     result.run_dir = run_dir
     result.config_dir = create_config_files.config_dir

--- a/python/integrationtest/integrationtest_drunc.py
+++ b/python/integrationtest/integrationtest_drunc.py
@@ -169,12 +169,12 @@ def create_config_files(request, tmp_path_factory):
         )
 
     consolidate_db(str(temp_config_db), str(config_db))
-
-    drunc_config.connsvc_port = set_connectivity_service_port(
-        oksfile=str(config_db),
-        session_name=drunc_config.session,
-        connsvc_port=drunc_config.connsvc_port, # Default is 0, which causes random port to be selected
-    )
+    if drunc_config.connsvc_port is not None:
+        drunc_config.connsvc_port = set_connectivity_service_port(
+            oksfile=str(config_db),
+            session_name=drunc_config.session,
+            connsvc_port=drunc_config.connsvc_port, # Default is 0, which causes random port to be selected
+        )
 
     dal = conffwk.dal.module("generated", "schema/appmodel/fdmodules.schema.xml")
     db = conffwk.Configuration("oksconflibs:" + str(config_db))
@@ -261,6 +261,7 @@ def run_nanorc(request, create_config_files, tmp_path_factory):
     if (
         not disable_connectivity_service
         and not create_config_files.config.drunc_connsvc
+        and create_config_files.config.connsvc_port is not None
     ):
         # start connsvc
         print(


### PR DESCRIPTION
Add ability to specify a session name different from the configuration session name
Add the ability to not touch the connectivity service port if `connsvc_port == None`, in this case we assume the integration test don't need to start it.