### PR TITLE
Added the setting of the TRACE_FILE env var in the OKS Session, if it…

### DIFF
--- a/python/integrationtest/integrationtest_drunc.py
+++ b/python/integrationtest/integrationtest_drunc.py
@@ -20,6 +20,9 @@ from daqconf.consolidate import consolidate_files, consolidate_db, copy_configur
 from daqconf.set_connectivity_service_port import (
     set_connectivity_service_port,
 )
+from daqconf.set_session_env_var import (
+    set_session_env_var,
+)
 from daqconf.get_session_apps import get_segment_apps
 import time
 import random
@@ -175,6 +178,14 @@ def create_config_files(request, tmp_path_factory):
             session_name=drunc_config.session,
             connsvc_port=drunc_config.connsvc_port, # Default is 0, which causes random port to be selected
         )
+
+    # 03-Jul-2025, KAB: added the setting of the TRACE_FILE env var in the OKS Session,
+    # if it is set in the user's environment, and if it is not already set in the configuration.
+    try:
+        trace_file_env_var = os.environ["TRACE_FILE"]
+        set_session_env_var(str(config_db), drunc_config.session, "TRACE_FILE", trace_file_env_var, overwrite=False)
+    except KeyError:
+        pass
 
     dal = conffwk.dal.module("generated", "schema/appmodel/fdmodules.schema.xml")
     db = conffwk.Configuration("oksconflibs:" + str(config_db))


### PR DESCRIPTION
… is set in the user's environment, and if it is not already set in the configuration.

Please note that this PR depends on [PR 582](https://github.com/DUNE-DAQ/daqconf/pull/582) in the `daqconf` repo.

It would be great if our regression tests always had TRACE messages enabled, if the user has the TRACE_FILE environmental variable set in their shell.

This is already provided for regression tests that make use of configurations that are generated for integtests.  However, it is not currently available for integtests that make use of pre-existing configuratiions.  An example of such an integtest is the `example_system_test` in the `daqsystemtest` repo.

To provide TRACE messages for integtests that use pre-existing configurations, I have added a call to the `set_session_env_var` Python function from the `daqconf` repo to the `integrationtest_drunc` file.  

I wanted to do this in a way that is backward compatible and does not disturb pre-existing values for TRACE_FILE in the configuration.  Pre-existing values may have been added manually by a user, or they could have been added to the configuration by the "generate" function that is used for most integtests.

To do this (not over-write existing TRACE_FILE values), I needed to modify the `set_session_env_var` function to accept an "overwrite" parameter.  That is the subject of [PR 582](https://github.com/DUNE-DAQ/daqconf/pull/582) in the `daqconf` repo.  

With the changes in this PR and the corresponding PR in `daqconf`, we automatically get TRACE messages from the example_system_test if the TRACE_FILE env var is set in the user's shell environment.

To test this, one can use the following steps:

- run a test without these changes and see that no TRACE messages are captured
    - `export TRACE_FILE=${DBT_AREA_ROOT}/log/${USER}_dunedaq.trace`
    - `daqsystemtest_integtest_bundle.sh -k example`
    - `tshow | tdelta -ct 1 | head`
- run a test with these changes and see that TRACE messages are captured
    - (I can provide detailed instructions, if desired)
