### PR TITLE
Added support for additional configuration-substitution options...

### DIFF
--- a/python/integrationtest/data_classes.py
+++ b/python/integrationtest/data_classes.py
@@ -11,11 +11,11 @@ class DROMap_config:
     flx_mode: str = "fix_rate"
 
 
-# 27-Aug-2025, KAB: added derived classes to handle various types of
-# configuration substitutions.  The attribute_substitution handles cases in which we
+# 27-Aug-2025, KAB: added derived classes to handle various types of configuration
+# substitutions.  The attribute_substitution class handles cases in which we
 # just need to replace simple value(s) for attribute(s) in a config object.
-# The relationship_substitution handles cases in which the new referenced "value"
-# is a configuration object. And, the list_element_substitution handles cases in
+# The relationship_substitution class handles cases in which the new referenced "value"
+# is a configuration object. And, the list_element_substitution class handles cases in
 # which the data item that we want to modify is an entry in a list within the specified
 # configuration object.
 # --> Implementation Note:  the "updates" dictionary that is currently part of the

--- a/python/integrationtest/data_classes.py
+++ b/python/integrationtest/data_classes.py
@@ -11,11 +11,37 @@ class DROMap_config:
     flx_mode: str = "fix_rate"
 
 
+# 27-Aug-2025, KAB: added derived classes to handle various types of
+# configuration substitutions.  The attribute_substitution handles cases in which we
+# just need to replace simple value(s) for attribute(s) in a config object.
+# The relationship_substitution handles cases in which the new referenced "value"
+# is a configuration object. And, the list_element_substitution handles cases in
+# which the data item that we want to modify is an entry in a list within the specified
+# configuration object.
+# --> Implementation Note:  the "updates" dictionary that is currently part of the
+#     config_substitution class should really be part of the attribute_substitution class.
+#     However, I've left it in config_substitution for backward-compatibility.  As we have
+#     time, We should change existing integtests to use attribute_substitution.  Once
+#     that is done, we should come back here and tighten up this code.
 @dataclass
 class config_substitution:
     obj_class: str
     obj_id: str = "*"
     updates: dict = field(default_factory=dict)
+
+@dataclass
+class attribute_substitution(config_substitution):
+    pass
+
+@dataclass
+class relationship_substitution(config_substitution):
+    rel_name: str = ""
+    replacement_object_class: str = ""
+    replacement_object_id: str = ""
+
+@dataclass
+class list_element_substitution(relationship_substitution):
+    list_index: int = 0
 
 
 @dataclass

--- a/python/integrationtest/data_classes.py
+++ b/python/integrationtest/data_classes.py
@@ -18,20 +18,14 @@ class DROMap_config:
 # is a configuration object. And, the list_element_substitution class handles cases in
 # which the data item that we want to modify is an entry in a list within the specified
 # configuration object.
-# --> Implementation Note:  the "updates" dictionary that is currently part of the
-#     config_substitution class should really be part of the attribute_substitution class.
-#     However, I've left it in config_substitution for backward-compatibility.  As we have
-#     time, We should change existing integtests to use attribute_substitution.  Once
-#     that is done, we should come back here and tighten up this code.
 @dataclass
 class config_substitution:
     obj_class: str
     obj_id: str = "*"
-    updates: dict = field(default_factory=dict)
 
 @dataclass
 class attribute_substitution(config_substitution):
-    pass
+    updates: dict = field(default_factory=dict)
 
 @dataclass
 class relationship_substitution(config_substitution):

--- a/python/integrationtest/integrationtest_drunc.py
+++ b/python/integrationtest/integrationtest_drunc.py
@@ -6,8 +6,14 @@ import os
 import pkg_resources
 import conffwk
 from integrationtest.integrationtest_commandline import file_exists
-from integrationtest.data_classes import CreateConfigResult
 from daqconf.generate_hwmap import generate_hwmap
+from integrationtest.data_classes import (
+    CreateConfigResult,
+    config_substitution,
+    attribute_substitution,
+    relationship_substitution,
+    list_element_substitution,
+)
 from daqconf.generate import (
     generate_readout,
     generate_fakedata,
@@ -191,8 +197,23 @@ def create_config_files(request, tmp_path_factory):
     db = conffwk.Configuration("oksconflibs:" + str(config_db))
 
     def apply_update(obj, substitution):
-        for name, value in substitution.updates.items():
-            setattr(obj, name, value)
+        # 27-Aug-2025, KAB: modified this code to support different types of substitutions
+        # --> Implementation Note:  support for bare instances of the config_substitution class has
+        #     been kept for backward-compatibility.  Once we have updated all existing integtests
+        #     to use attribute_substitution, we should come back here and tighten up this code.
+        if isinstance(substitution, list_element_substitution):
+            replacement_obj = db.get_dal(substitution.replacement_object_class, substitution.replacement_object_id)
+            the_list = getattr(obj, substitution.rel_name)
+            the_list[substitution.list_index] = replacement_obj
+            setattr(obj, substitution.rel_name, the_list)
+        elif isinstance(substitution, relationship_substitution):
+            replacement_obj = db.get_dal(substitution.replacement_object_class, substitution.replacement_object_id)
+            setattr(obj, substitution.rel_name, replacement_obj)
+        elif isinstance(substitution, attribute_substitution) or isinstance(substitution, config_substitution):
+            for name, value in substitution.updates.items():
+                setattr(obj, name, value)
+        else:
+            print(f"*** ERROR: Unexpected configuration substitution type *** (\"{substitution}\")")
 
         db.update_dal(obj)
 

--- a/python/integrationtest/integrationtest_drunc.py
+++ b/python/integrationtest/integrationtest_drunc.py
@@ -198,9 +198,6 @@ def create_config_files(request, tmp_path_factory):
 
     def apply_update(obj, substitution):
         # 27-Aug-2025, KAB: modified this code to support different types of substitutions
-        # --> Implementation Note:  support for bare instances of the config_substitution class has
-        #     been kept for backward-compatibility.  Once we have updated all existing integtests
-        #     to use attribute_substitution, we should come back here and tighten up this code.
         if isinstance(substitution, list_element_substitution):
             replacement_obj = db.get_dal(substitution.replacement_object_class, substitution.replacement_object_id)
             the_list = getattr(obj, substitution.rel_name)
@@ -209,7 +206,7 @@ def create_config_files(request, tmp_path_factory):
         elif isinstance(substitution, relationship_substitution):
             replacement_obj = db.get_dal(substitution.replacement_object_class, substitution.replacement_object_id)
             setattr(obj, substitution.rel_name, replacement_obj)
-        elif isinstance(substitution, attribute_substitution) or isinstance(substitution, config_substitution):
+        elif isinstance(substitution, attribute_substitution):
             for name, value in substitution.updates.items():
                 setattr(obj, name, value)
         else:

--- a/python/integrationtest/integrationtest_drunc.py
+++ b/python/integrationtest/integrationtest_drunc.py
@@ -6,7 +6,6 @@ import os
 import pkg_resources
 import conffwk
 from integrationtest.integrationtest_commandline import file_exists
-from daqconf.generate_hwmap import generate_hwmap
 from integrationtest.data_classes import (
     CreateConfigResult,
     config_substitution,
@@ -14,6 +13,7 @@ from integrationtest.data_classes import (
     relationship_substitution,
     list_element_substitution,
 )
+from daqconf.generate_hwmap import generate_hwmap
 from daqconf.generate import (
     generate_readout,
     generate_fakedata,


### PR DESCRIPTION
...such as when the replacement entity is a configuration object instead of just a simple value.

## Description

These changes are needed to allow us to reduce duplication of sample configurations in `daqsystemtest/example-configs`. 

The new functionality in this repo will allow us to specify more sophisticated configuration substitutions in our integtest files.

This PR is part of DUNE-DAQ/daq-deliverables#181.

## Testing Suggestions

The changes in this PR can be tested and merged independently of any other changes, but follow-on changes in `daqsystemtest`, `asiolibs`, and `crtmodules` will depend on these changes.  To test the backward-compatibility of these changes, one would simply install the modified code in a local software area (e.g. `pip install -U .`) and run existing regression tests. 

