### PR TITLE
Changes to support TDEEth TPG in regression tests

### DIFF
--- a/src/integrationtest/data_classes.py
+++ b/src/integrationtest/data_classes.py
@@ -9,6 +9,8 @@ class DROMap_config:
     app_host: str = "localhost"
     eth_protocol: str = "udp"
     flx_mode: str = "fix_rate"
+    crate_id_offset: int = 1
+    slot_id: int = 0
 
 
 # 27-Aug-2025, KAB: added derived classes to handle various types of configuration

--- a/src/integrationtest/data_classes.py
+++ b/src/integrationtest/data_classes.py
@@ -15,9 +15,10 @@ class DROMap_config:
 # substitutions.  The attribute_substitution class handles cases in which we
 # just need to replace simple value(s) for attribute(s) in a config object.
 # The relationship_substitution class handles cases in which the new referenced "value"
-# is a configuration object. And, the list_element_substitution class handles cases in
+# is a configuration object. The list_element_substitution class handles cases in
 # which the data item that we want to modify is an entry in a list within the specified
-# configuration object.
+# configuration object. And, the list_element_addition class handles cases in which
+# we want to add a data item to a list within the specified configuration object.
 @dataclass
 class config_substitution:
     obj_class: str
@@ -37,6 +38,11 @@ class relationship_substitution(config_substitution):
 class list_element_substitution(relationship_substitution):
     list_index: int = 0
 
+@dataclass
+class list_element_addition(config_substitution):
+    rel_name: str = ""
+    additional_object_class: str = ""
+    additional_object_id: str = ""
 
 @dataclass
 class drunc_config:

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -124,6 +124,8 @@ def create_config_files(request, tmp_path_factory):
                         dro_map_config.app_host,
                         dro_map_config.eth_protocol,
                         dro_map_config.flx_mode,
+                        dro_map_config.crate_id_offset,
+                        dro_map_config.slot_id,
                     )
 
             if not file_exists(readout_db):

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -12,6 +12,7 @@ from integrationtest.data_classes import (
     attribute_substitution,
     relationship_substitution,
     list_element_substitution,
+    list_element_addition,
 )
 from daqconf.generate_hwmap import generate_hwmap
 from daqconf.generate import (
@@ -199,7 +200,12 @@ def create_config_files(request, tmp_path_factory):
 
     def apply_update(obj, substitution):
         # 27-Aug-2025, KAB: modified this code to support different types of substitutions
-        if isinstance(substitution, list_element_substitution):
+        if isinstance(substitution, list_element_addition):
+            additional_obj = db.get_dal(substitution.additional_object_class, substitution.additional_object_id)
+            the_list = getattr(obj, substitution.rel_name)
+            the_list.append(additional_obj)
+            setattr(obj, substitution.rel_name, the_list)
+        elif isinstance(substitution, list_element_substitution):
             replacement_obj = db.get_dal(substitution.replacement_object_class, substitution.replacement_object_id)
             the_list = getattr(obj, substitution.rel_name)
             the_list[substitution.list_index] = replacement_obj


### PR DESCRIPTION
## Description

These changes are part of DUNE-DAQ/daqsystemtest#243, and they consist of the following additions:

- support for specifying a crate_id and slot_id was added to the `DROMap_config` data structure.  This is needed so that we can use the same GeoId in our fake-data-replay systems as what was assigned when the data was taken with the real electronics.
- support for adding a configuration parameter to the end of an existing list.  This is needed so that we can add a readout window for kPrescale triggers to the existing list of readout window settings for other trigger types.

These changes could be merged before changes in other repos, but the changes in `daqconf` and `daqsystemtest` depend on these.

## Testing Suggestions

Please see the instructions listed in DUNE-DAQ/daqsystemtest#243.

