### PR TITLE
Modified the default frame file provided in the drunc_config class to use a recent data file.

### DIFF
--- a/src/integrationtest/data_classes.py
+++ b/src/integrationtest/data_classes.py
@@ -44,7 +44,7 @@ class drunc_config:
     session: str = "integtest"
     session_name: str = None
     dro_map_config: DROMap_config = field(default_factory=lambda: DROMap_config(1))
-    frame_file: str = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e"
+    frame_file: str = "asset://?checksum=370df564205290d27cab47e44ae4ca47"
     tpg_enabled: bool = False
     trmon_app_enabled: bool = False
     fake_hsi_enabled: bool = False


### PR DESCRIPTION
## Description

DUNE-DAQ/daqsystemtest#245 requests that we update our regression tests, etc. to use recent data-replay files from the _assets_ system.

In this repo, that translated to changing the checksum of the default asset file that is used in integration tests.  The new file is `wib_link_67.bin`, which was recently created by Eric.

## Testing Suggestions

There are suggestions in DUNE-DAQ/daqsystemtest#245 for testing all of the asset-file-update changes together.
