### PR TITLE
Added the setting of a random rc_controller port in integrationtest_drunc.py...

### DIFF
--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -27,6 +27,9 @@ from daqconf.consolidate import consolidate_files, consolidate_db, copy_configur
 from daqconf.set_connectivity_service_port import (
     set_connectivity_service_port,
 )
+from daqconf.set_rc_controller_port import (
+    set_rc_controller_port,
+)
 from daqconf.set_session_env_var import (
     set_session_env_var,
 )
@@ -188,6 +191,8 @@ def create_config_files(request, tmp_path_factory):
             session_name=drunc_config.session,
             connsvc_port=drunc_config.connsvc_port, # Default is 0, which causes random port to be selected
         )
+    # 05-Nov-2025, KAB, MiR: added the setting of a random RC port
+    set_rc_controller_port(oksfile=str(config_db), session_name=drunc_config.session, rc_port=0)
 
     # 03-Jul-2025, KAB: added the setting of the TRACE_FILE env var in the OKS Session,
     # if it is set in the user's environment, and if it is not already set in the configuration.


### PR DESCRIPTION
…to support the running of multiple regression tests at the same time on a single computer.

# Description

These changes go along with the ones that Michal has made on his `mrigan/k8s_pm_update` branches in daqconf, daqsystemtest, and drunc, and they are needed to restore the ability to successfully run multiple simultaneous regression tests on a single computer.

To test the changes, you should create a software area with Michal's changes included, then start up two Linux sessions and start regression tests at the same time in each of them.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.

## Correlated Changes

* DUNE-DAQ/drunc#657
* DUNE-DAQ/daqconf#608
* DUNE-DAQ/daqsystemtest#260
