### PR TITLE
Switched to using the trigger_type value in the TriggerRecordHeader…

### DIFF
--- a/src/integrationtest/data_file_check_utilities.py
+++ b/src/integrationtest/data_file_check_utilities.py
@@ -7,15 +7,19 @@ import trgdataformats
 from daqdataformats import FragmentErrorBits
 from hdf5libs import HDF5RawDataFile
 
-def get_TC_type(h5_file, record_id):
+def get_TC_types(h5_file, record_id) -> list:
+    type_list = []
     src_ids = h5_file.get_source_ids_for_fragment_type(record_id, 'Trigger_Candidate')
     if len(src_ids) == 1:
         for src_id in src_ids:
             frag = h5_file.get_frag(record_id, src_id);
             if frag.get_size() > 72:
-                tc = trgdataformats.TriggerCandidate(frag.get_data())
-                return trgdataformats.trigger_candidate_type_to_string(tc.data.type)
-    return "kUnknown"
+                tc_byte_offset = 0
+                while tc_byte_offset < frag.get_data_size():
+                    tc = trgdataformats.TriggerCandidate(frag.get_data(tc_byte_offset))
+                    type_list.append(trgdataformats.trigger_candidate_type_to_string(tc.data.type))
+                    tc_byte_offset += tc.sizeof()
+    return type_list
 
 # 17-Nov-2025, KAB: added a function to get the trigger type string (e.g. kTiming)
 # based on the trigger_type field in the TriggerRecordHeader. (I also modified the

--- a/src/integrationtest/data_file_check_utilities.py
+++ b/src/integrationtest/data_file_check_utilities.py
@@ -17,6 +17,14 @@ def get_TC_type(h5_file, record_id):
                 return trgdataformats.trigger_candidate_type_to_string(tc.data.type)
     return "kUnknown"
 
+# 17-Nov-2025, KAB: added a function to get the trigger type string (e.g. kTiming)
+# based on the trigger_type field in the TriggerRecordHeader. (I also modified the
+# data_file_checks that make use of the trigger type to use this new function now.)
+# Previously, the TC_type was used.  I kept the function that fetched the TC_type above,
+# but there may no longer be a need for it.  TC_type is not reliable when there is more
+# than one TC in the TriggerCandidate fragment in the TriggerRecord.  Multiple TCs in
+# a single TC fragment can happen when there are multiple triggers configured for a run,
+# and two or more of them occur at the same time.
 def get_trigger_type_string(h5_file, record_id):
     if not h5_file.is_trigger_record_type():
         return "kUnknown"

--- a/src/integrationtest/data_file_check_utilities.py
+++ b/src/integrationtest/data_file_check_utilities.py
@@ -17,6 +17,15 @@ def get_TC_type(h5_file, record_id):
                 return trgdataformats.trigger_candidate_type_to_string(tc.data.type)
     return "kUnknown"
 
+def get_trigger_type_string(h5_file, record_id):
+    if not h5_file.is_trigger_record_type():
+        return "kUnknown"
+    trig_rec = h5_file.get_trigger_record(record_id)
+    tr_header = trig_rec.get_header_data()
+    trigger_type = tr_header.trigger_type
+    type_enum_value = trgdataformats.TriggerCandidateData.Type(power_of_two_exponent(trigger_type))
+    return trgdataformats.trigger_candidate_type_to_string(type_enum_value)
+
 def get_record_ordinal_strings(record_id, full_record_list):
     ordinal_strings = []
     try:

--- a/src/integrationtest/data_file_checks.py
+++ b/src/integrationtest/data_file_checks.py
@@ -4,7 +4,7 @@ import os.path
 import re
 from hdf5libs import HDF5RawDataFile
 from integrationtest.data_file_check_utilities import (
-    get_TC_type,
+    get_trigger_type_string,
     get_record_ordinal_strings,
     get_fragment_count_limits,
     get_fragment_size_limits,
@@ -145,11 +145,11 @@ def check_fragment_count(datafile, params):
     h5_file = HDF5RawDataFile(datafile.name)
     records = h5_file.get_all_record_ids()
     for rec in records:
-        tc_type_string = get_TC_type(h5_file, rec)
+        trigger_type_string = get_trigger_type_string(h5_file, rec)
         rno_strings = get_record_ordinal_strings(rec, records)
-        fragment_count_limits = get_fragment_count_limits(params, tc_type_string, rno_strings)
+        fragment_count_limits = get_fragment_count_limits(params, trigger_type_string, rno_strings)
         if (debug_mask & 0x1) != 0:
-            print(f'DataFileChecks Debug: the fragment count limits are {fragment_count_limits} for TC type {tc_type_string} and record ordinal strings {rno_strings}')
+            print(f'DataFileChecks Debug: the fragment count limits are {fragment_count_limits} for TC type {trigger_type_string} and record ordinal strings {rno_strings}')
         if fragment_count_limits[0] not in min_count_list:
             min_count_list.append(fragment_count_limits[0])
         if fragment_count_limits[1] not in max_count_list:
@@ -201,11 +201,11 @@ def check_fragment_sizes(datafile, params):
     h5_file = HDF5RawDataFile(datafile.name)
     records = h5_file.get_all_record_ids()
     for rec in records:
-        tc_type_string = get_TC_type(h5_file, rec)
+        trigger_type_string = get_trigger_type_string(h5_file, rec)
         rno_strings = get_record_ordinal_strings(rec, records)
-        size_limits = get_fragment_size_limits(params, tc_type_string, rno_strings)
+        size_limits = get_fragment_size_limits(params, trigger_type_string, rno_strings)
         if (debug_mask & 0x4) != 0:
-            print(f'DataFileChecks Debug: the fragment size limits are {size_limits} for TC type {tc_type_string} and record ordinal strings {rno_strings}')
+            print(f'DataFileChecks Debug: the fragment size limits are {size_limits} for TC type {trigger_type_string} and record ordinal strings {rno_strings}')
         if size_limits[0] not in min_size_list:
             min_size_list.append(size_limits[0])
         if size_limits[1] not in max_size_list:
@@ -254,11 +254,11 @@ def check_fragment_error_flags(datafile, params):
     h5_file = HDF5RawDataFile(datafile.name)
     records = h5_file.get_all_record_ids()
     for rec in records:
-        tc_type_string = get_TC_type(h5_file, rec)
+        trigger_type_string = get_trigger_type_string(h5_file, rec)
         rno_strings = get_record_ordinal_strings(rec, records)
-        error_bitmask = get_fragment_error_bitmask(params, tc_type_string, rno_strings)
+        error_bitmask = get_fragment_error_bitmask(params, trigger_type_string, rno_strings)
         if (debug_mask & 0x4) != 0:
-            print(f'DataFileChecks Debug: the fragment error bitmask is {hex(error_bitmask)} for TC type {tc_type_string} and record ordinal strings {rno_strings}')
+            print(f'DataFileChecks Debug: the fragment error bitmask is {hex(error_bitmask)} for TC type {trigger_type_string} and record ordinal strings {rno_strings}')
         if error_bitmask not in error_mask_list:
             error_mask_list.append(error_bitmask)
         if subdet_string == "":

--- a/src/integrationtest/data_file_checks.py
+++ b/src/integrationtest/data_file_checks.py
@@ -4,6 +4,7 @@ import os.path
 import re
 from hdf5libs import HDF5RawDataFile
 from integrationtest.data_file_check_utilities import (
+    get_TC_types,
     get_trigger_type_string,
     get_record_ordinal_strings,
     get_fragment_count_limits,
@@ -51,6 +52,18 @@ def sanity_check(datafile):
         if triggerrecordheader_count > 1:
             print(f"\N{POLICE CARS REVOLVING LIGHT} More than one TriggerRecordHeader in record {event} \N{POLICE CARS REVOLVING LIGHT}")
             passed=False
+
+    # check that the trigger_type in the TriggerRecordHeader matches one of the
+    # TriggerCandidates in the TC fragment
+    h5_file = HDF5RawDataFile(datafile.name)
+    records = h5_file.get_all_record_ids()
+    for rec in records:
+        trigger_type_string = get_trigger_type_string(h5_file, rec)
+        TC_type_list = get_TC_types(h5_file, rec)
+        if trigger_type_string not in TC_type_list or len(TC_type_list) > 1:
+            print(f"\N{POLICE CARS REVOLVING LIGHT} The trigger_type in the TriggerRecordHeader ({trigger_type_string}) does not match any of the TriggerCandidates in the record ({TC_type_list}) \N{POLICE CARS REVOLVING LIGHT}")
+            passed=False
+
     if passed:
         print("\N{WHITE HEAVY CHECK MARK} Sanity-check passed")
     return passed

--- a/src/integrationtest/data_file_checks.py
+++ b/src/integrationtest/data_file_checks.py
@@ -61,7 +61,7 @@ def sanity_check(datafile):
     for rec in records:
         trigger_type_string = get_trigger_type_string(h5_file, rec)
         TC_type_list = get_TC_types(h5_file, rec)
-        if trigger_type_string not in TC_type_list or len(TC_type_list) > 1:
+        if trigger_type_string not in TC_type_list:
             print(f"\N{POLICE CARS REVOLVING LIGHT} The trigger_type in the TriggerRecordHeader ({trigger_type_string}) does not match any of the TriggerCandidates in the record ({TC_type_list}) \N{POLICE CARS REVOLVING LIGHT}")
             passed=False
 


### PR DESCRIPTION
…to decide which custom comparison values to use in data file tests, instead of using the first TC type found in the data (which is not reliable).

These changes are targeted to `fddaq-v5.6.0`...

# Description

A long-standing action item has been to switch from using the first TC type in the Trigger Candidate data fragment to the trigger_type field in the TriggerRecordHeader to determine the trigger type for a given Trigger Record in an HDF5 file.  

The choice of the TC type was probably a historical accident, and it is not a reliable indicator of what the trigger was, when we have overlapping TriggerCandidates.

Recall that the trigger type is used in the integtest infrastruture (e.g. `data_file_checks`) to decide which low and high bounds to use in various tests.  For example, we can have different fragment size ranges for `kTiming` triggers vs. `kRandom` or `kPrescale` triggers.

I was reminded of the unreliability of using one of the TC types in the TC fragment recently when running `daqsystemtest` regression tests at EHN1 that produced an occasional fragment size mismatch that I believe was caused by this poor historical choice.

The code changes in the PR are my attempt to remedy this situation.  I took ideas and/or code from Michal's trigger_type lookup in the `check_tr_type` functions that he added to the integrationtest infrastructure a while ago.

For better or worse, the way to test this is to run the regression tests many times and verify that we don't have fragment sizes out of range when there are multiple trigger types in the run.

This PR is loosely coupled with DUNE-DAQ/daqsystemtest#264.  I say this because I believe that the problem that this PR addresses will happen slightly more often when the changes in the `daqsystemtest` PR are included...

**An additional change**, suggested by Eric:  I've added a sanity check for TriggerRecord files that verifies that the `trigger_type` field in the TriggerRecordHeader matches one of the TriggerCandidate types in the TriggerCandidate fragment.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
