### PR TITLE
Added the ability to validate the "run_was_for_test_purposes" HDF5 File Attribute

### DIFF
--- a/src/integrationtest/data_file_checks.py
+++ b/src/integrationtest/data_file_checks.py
@@ -55,7 +55,11 @@ def sanity_check(datafile):
         print("\N{WHITE HEAVY CHECK MARK} Sanity-check passed")
     return passed
 
-def check_file_attributes(datafile):
+# 17-Nov-2025, KAB: added the 'was_test_run' function argument to allow us
+# to validate the run_was_for_test_purposes Attribute value.  Valid values
+# are the strings "true" and "false", which is easiest given that the values
+# in the HDF5 Attribute are lower-case strings.
+def check_file_attributes(datafile, was_test_run="true"):
     "Checking that the expected Attributes exist within the data file"
     passed=True
     base_filename = os.path.basename(datafile.h5file.filename)
@@ -103,6 +107,12 @@ def check_file_attributes(datafile):
                 passed=False
                 print(f"\N{POLICE CARS REVOLVING LIGHT} The value in Attribute '{expected_attr_name}' ({date_string}) does not match the value in the filename ({base_filename}) \N{POLICE CARS REVOLVING LIGHT}")
                 print(f"\N{POLICE CARS REVOLVING LIGHT} Debug information: pattern_low={pattern_low} pattern_high={pattern_high} pattern_exact={pattern_exact} \N{POLICE CARS REVOLVING LIGHT}")
+        elif expected_attr_name == "run_was_for_test_purposes":
+            # value from the Attribute
+            attr_value = datafile.h5file.attrs.get(expected_attr_name)
+            if attr_value != was_test_run:
+                passed=False
+                print(f"\N{POLICE CARS REVOLVING LIGHT} The value in Attribute '{expected_attr_name}' ({attr_value}) does not match the expected value ({was_test_run}) \N{POLICE CARS REVOLVING LIGHT}")
     if passed:
         print(f"\N{WHITE HEAVY CHECK MARK} All Attribute tests passed for file {base_filename}")
     return passed

--- a/src/integrationtest/data_file_checks.py
+++ b/src/integrationtest/data_file_checks.py
@@ -33,6 +33,7 @@ class DataFile:
 def sanity_check(datafile):
     "Very basic sanity checks on file"
     passed=True
+    base_filename = os.path.basename(datafile.h5file.filename)
     print("") # Clear potential dot from pytest
 
     # execute unit tests for local function(s)
@@ -52,7 +53,9 @@ def sanity_check(datafile):
             print(f"\N{POLICE CARS REVOLVING LIGHT} More than one TriggerRecordHeader in record {event} \N{POLICE CARS REVOLVING LIGHT}")
             passed=False
     if passed:
-        print("\N{WHITE HEAVY CHECK MARK} Sanity-check passed")
+        print(f"\N{WHITE HEAVY CHECK MARK} Sanity-check passed for file {base_filename}")
+    else:
+        print(f"\N{POLICE CARS REVOLVING LIGHT} One or more sanity-checks failed for file {base_filename} \N{POLICE CARS REVOLVING LIGHT}")
     return passed
 
 # 17-Nov-2025, KAB: added the 'was_test_run' function argument to allow us
@@ -80,7 +83,7 @@ def check_file_attributes(datafile, was_test_run="true"):
                 filename_value = int(re.sub('run','',re.sub('_','',match_obj.group(0))))
                 if attr_value != filename_value:
                     passed=False
-                    print(f"\N{POLICE CARS REVOLVING LIGHT} The value in Attribute '{expected_attr_name}' ({attr_value}) does not match the value in the filename ({base_filename}) \N{POLICE CARS REVOLVING LIGHT}")
+                    print(f"\N{POLICE CARS REVOLVING LIGHT} The value in HDF5 File Attribute '{expected_attr_name}' ({attr_value}) does not match the value in the filename ({base_filename}) \N{POLICE CARS REVOLVING LIGHT}")
         elif expected_attr_name == "file_index":
             # value from the Attribute
             attr_value = datafile.h5file.attrs.get(expected_attr_name)
@@ -91,7 +94,7 @@ def check_file_attributes(datafile, was_test_run="true"):
                 filename_value = int(re.sub('_','',match_obj.group(0)))
                 if attr_value != filename_value:
                     passed=False
-                    print(f"\N{POLICE CARS REVOLVING LIGHT} The value in Attribute '{expected_attr_name}' ({attr_value}) does not match the value in the filename ({base_filename}) \N{POLICE CARS REVOLVING LIGHT}")
+                    print(f"\N{POLICE CARS REVOLVING LIGHT} The value in HDF5 File Attribute '{expected_attr_name}' ({attr_value}) does not match the value in the filename ({base_filename}) \N{POLICE CARS REVOLVING LIGHT}")
         elif expected_attr_name == "creation_timestamp":
             attr_value = datafile.h5file.attrs.get(expected_attr_name)
             date_obj = datetime.datetime.fromtimestamp((int(attr_value)/1000)-1, datetime.timezone.utc)
@@ -105,16 +108,16 @@ def check_file_attributes(datafile, was_test_run="true"):
             pattern_exact = f".*{date_string}.*"
             if not re.match(pattern_exact, base_filename) and not re.match(pattern_low, base_filename) and not re.match(pattern_high, base_filename):
                 passed=False
-                print(f"\N{POLICE CARS REVOLVING LIGHT} The value in Attribute '{expected_attr_name}' ({date_string}) does not match the value in the filename ({base_filename}) \N{POLICE CARS REVOLVING LIGHT}")
+                print(f"\N{POLICE CARS REVOLVING LIGHT} The value in HDF5 File Attribute '{expected_attr_name}' ({date_string}) does not match the value in the filename ({base_filename}) \N{POLICE CARS REVOLVING LIGHT}")
                 print(f"\N{POLICE CARS REVOLVING LIGHT} Debug information: pattern_low={pattern_low} pattern_high={pattern_high} pattern_exact={pattern_exact} \N{POLICE CARS REVOLVING LIGHT}")
         elif expected_attr_name == "run_was_for_test_purposes":
             # value from the Attribute
             attr_value = datafile.h5file.attrs.get(expected_attr_name)
             if attr_value != was_test_run:
                 passed=False
-                print(f"\N{POLICE CARS REVOLVING LIGHT} The value in Attribute '{expected_attr_name}' ({attr_value}) does not match the expected value ({was_test_run}) \N{POLICE CARS REVOLVING LIGHT}")
+                print(f"\N{POLICE CARS REVOLVING LIGHT} The value in HDF5 File Attribute '{expected_attr_name}' ({attr_value}) does not match the expected value ({was_test_run}) \N{POLICE CARS REVOLVING LIGHT}")
     if passed:
-        print(f"\N{WHITE HEAVY CHECK MARK} All Attribute tests passed for file {base_filename}")
+        print(f"\N{WHITE HEAVY CHECK MARK} All Attribute tests passed")
     return passed
 
 def check_event_count(datafile, expected_value, tolerance):


### PR DESCRIPTION
These changes are intended to be included in `fddaq-v5.6.0`...

# Description

It will be helpful to be able to check the value of the `run_was_for_test_purposes` Attribute in the HDF5 files created in regression tests, and the changes that are part of this PR make that possible.  

While testing these changes, I noticed that the name of the HDF5 file was not being printed out when there was a problem found in the Attributes.  Since it is very nice to see the name of this file in the console output, I moved it to the "sanity check" function.  Such a printout should probably go into the regresstion test files themselves, but this was a easy change that helped, and we can look into moving the filename printout to the regression test files when we make wider-scope changes (like changing "nanorc" to "drunc" or "dunerc")...

For now, testing this change should just be to confirm that it didn't break anything in existing regression/integtests.

Soon after this PR is approved and merged, I will create a new test that verifies that the `--run-type=PROD` option to the `drunc` `start` command has the desired effect on the file attributes...

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
