### PR TITLE
Modified the check on valid trigger_types in data_file_checks/sanity_check…

### DIFF
--- a/src/integrationtest/data_file_checks.py
+++ b/src/integrationtest/data_file_checks.py
@@ -61,8 +61,14 @@ def sanity_check(datafile):
     for rec in records:
         trigger_type_string = get_trigger_type_string(h5_file, rec)
         TC_type_list = get_TC_types(h5_file, rec)
-        if trigger_type_string not in TC_type_list:
-            print(f"\N{POLICE CARS REVOLVING LIGHT} The trigger_type in the TriggerRecordHeader ({trigger_type_string}) does not match any of the TriggerCandidates in the record ({TC_type_list}) \N{POLICE CARS REVOLVING LIGHT}")
+        # 20-Nov-2025, KAB: added the condition that the trigger record sequence number is zero to the following test.
+        # The reason for this is that when triggers with long readout windows are split into a sequence of
+        # trigger records, typically only the first TR in the sequence has a non-empty TriggerCandidate fragment.
+        # We don't want to complain about an invalid trigger type for the remaining TRs in the sequence when those
+        # TRs are expected to have an empty TC fragment.  Of course, it would be really great if all TRs in the
+        # sequence would have a non-empty TC fragment, but that is a problem for another day.
+        if trigger_type_string not in TC_type_list and rec[1] == 0:
+            print(f"\N{POLICE CARS REVOLVING LIGHT} The trigger_type in the TriggerRecordHeader ({trigger_type_string}) does not match any of the TriggerCandidate types ({TC_type_list}) in record {rec} \N{POLICE CARS REVOLVING LIGHT}")
             passed=False
 
     if passed:


### PR DESCRIPTION
…so that it doesn't complain about TriggerRecords with sequence number greater than zero since those are known to have empty TC fragments.

This change is targeted to the `develop` branch of this repo, so that means that it is targeted to `fddaq-v5.6.0`.

# Description

We noticed that the change that was made yesterday to add `trigger_type` checking to the `sanity_check` part of integration tests was producing a lot of undesired errors in the `long_window_readout_test` in `daqsystemtest`.  This is because triggers with long readout windows are split up into sequences of TriggerRecords, and only the first TR in the sequence gets a valid TriggerCandidate fragment.  (The contents of the TC fragment are used to validate the `trigger_type`.)

The change in this PR restricts the validation check to only the first TriggerRecord in a sequence.

Running the `long_window_readout_test.py` without and with this change should demonstrate the undesired failures (before) and the clean running of the test (after).

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

