### PR TITLE
Added validation functions for opmon metrics

### DIFF
--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -479,6 +479,6 @@ def run_nanorc(request, create_config_files, tmp_path_factory):
             trmon_dir.glob(f"{create_config_files.config.op_env}_trmon_*.hdf5")
         )
     result.log_files = list(run_dir.glob("log_*.txt")) + list(run_dir.glob("log_*.log"))
-    result.opmon_files = list(run_dir.glob("info_*.json"))
+    result.opmon_files = list(run_dir.glob(f"info*{result.session_name if result.session_name else result.session}*.json"))
     print("---------- DRUNC Run END ----------", flush=True)
     yield result

--- a/src/integrationtest/opmon_metric_checks.py
+++ b/src/integrationtest/opmon_metric_checks.py
@@ -1,0 +1,128 @@
+from opmonlib.info_file_collator import collate_info_files
+
+# modify the print() statement default behavior so that it always flushes the output.
+import functools
+print = functools.partial(print, flush=True)
+
+
+# simple wrapper for the function in opmonlib that collates metric files
+def collate_opmon_data_from_files(json_files: list) -> dict:
+    return collate_info_files(json_files)
+
+
+# Function to check whether the number of samples reported in the specified collection
+# of opmon data for the specified metric name is within the specified range.
+# The metric name is specified as a list of dictionary keys.  For example:
+#   [session_name, "df-01", "df-01-trb", "dfmodules.TRBInfo", "generated_trigger_records"]
+# The default upper bound on the number of samples is -1, which is a special value that means "unbounded."
+# The default lower bound on the number of samples is 1.
+# So, the default behavior of this function is to check that there is at least one sample.
+# Returns False if a problem is encountered (e.g. parsing the collated JSON metric data)
+# or the sample count is out of the requested range.  True otherwise.
+def check_metric_sample_count(collated_opmon_data: dict, dict_key_list: list, min_count=1, max_count=-1):
+    full_key_path = dict_key_list[0]
+    for key_name in dict_key_list[1:]:
+        full_key_path += "/" + str(key_name)
+    "Checking that the number of {full_key_path} metric samples is within its allowed range"
+
+    # sanity check - make sure that we really have a dictionary
+    working_dict = collated_opmon_data
+    if not isinstance(working_dict, dict):
+        print(f"\N{POLICE CARS REVOLVING LIGHT} The data type of the collated opmon data ({type(working_dict)}) is not 'dictionary', as it needs to be. \N{POLICE CARS REVOLVING LIGHT}")
+        return False
+
+    # work our way down the nested dictionaries until we get to the requested metric values
+    for key_name in dict_key_list:
+        # if the user specified a key name of "*", we just use the first available key
+        if key_name == "*":
+            key_list = list(working_dict.keys())
+            first_key = key_list[0]
+            working_dict = working_dict[first_key]
+        # otherwise, we fetch the requested key, if it's available
+        elif key_name in working_dict.keys():
+            working_dict = working_dict[key_name]
+        # otherwise, we bail out
+        else:
+            print(f"\N{POLICE CARS REVOLVING LIGHT} Unable to find the data for key \"{key_name}\" when looking up metric \"{full_key_path}\" in collated opmon data. \N{POLICE CARS REVOLVING LIGHT}")
+            return False
+
+        # sanity check - make sure that we really have a dictionary at the next level in the tree
+        if not isinstance(working_dict, dict):
+            print(f"\N{POLICE CARS REVOLVING LIGHT} The data type of the opmon data associated with the '{key_name}' key ({type(working_dict)}) is not 'dictionary', as it needs to be. \N{POLICE CARS REVOLVING LIGHT}")
+            return False
+
+    number_of_samples = len(working_dict)
+    if max_count == -1:
+        if number_of_samples < min_count:
+            print(f"\N{POLICE CARS REVOLVING LIGHT} The number of metric samples for key \"{full_key_path}\" ({number_of_samples}) is outside the expected range ({min_count}..unbounded). \N{POLICE CARS REVOLVING LIGHT}")
+            return False
+        else:
+            print(f"\N{WHITE HEAVY CHECK MARK} The number of metric samples for key \"{full_key_path}\" ({number_of_samples}) is within the expected range ({min_count}..unbounded). \N{WHITE HEAVY CHECK MARK}")
+            return True
+    else:
+        if number_of_samples < min_count or number_of_samples > max_count:
+            print(f"\N{POLICE CARS REVOLVING LIGHT} The number of metric samples for key \"{full_key_path}\" ({number_of_samples}) is outside the expected range ({min_count}..{max_count}). \N{POLICE CARS REVOLVING LIGHT}")
+            return False
+        else:
+            print(f"\N{WHITE HEAVY CHECK MARK} The number of metric samples for key \"{full_key_path}\" ({number_of_samples}) is within the expected range ({min_count}..{max_count}). \N{WHITE HEAVY CHECK MARK}")
+            return True
+
+
+# Function to check whether the values reported in the specified collection of opmon data for
+# the specified metric name sum up to a total that is within the specified range.
+# The metric name is specified as a list of dictionary keys.  For example:
+#   [session_name, "df-01", "df-01-trb", "dfmodules.TRBInfo", "generated_trigger_records"]
+# The default upper bound on the sum of the values is -1, which is a special value that means "unbounded."
+# The default lower bound on the sum of the values is 1.
+# So, the default behavior of this function is to check that there is at least one non-zero metric value.
+# Returns False if a problem is encountered (e.g. parsing the collated JSON metric data)
+# or the value sum is out of the requested range.  True otherwise.
+def check_metric_value_sum(collated_opmon_data: dict, dict_key_list: list, min_value_sum=1, max_value_sum=-1):
+    full_key_path = dict_key_list[0]
+    for key_name in dict_key_list[1:]:
+        full_key_path += "/" + str(key_name)
+    "Checking that the sum of {full_key_path} metric values is within its allowed range"
+
+    # sanity check - make sure that we really have a dictionary
+    working_dict = collated_opmon_data
+    if not isinstance(working_dict, dict):
+        print(f"\N{POLICE CARS REVOLVING LIGHT} The data type of the collated opmon data ({type(working_dict)}) is not 'dictionary', as it needs to be. \N{POLICE CARS REVOLVING LIGHT}")
+        return False
+
+    # work our way down the nested dictionaries until we get to the requested metric values
+    for key_name in dict_key_list:
+        # if the user specified a key name of "*", we just use the first available key
+        if key_name == "*":
+            key_list = list(working_dict.keys())
+            first_key = key_list[0]
+            working_dict = working_dict[first_key]
+        # otherwise, we fetch the requested key, if it's available
+        elif key_name in working_dict.keys():
+            working_dict = working_dict[key_name]
+        # otherwise, we bail out
+        else:
+            print(f"\N{POLICE CARS REVOLVING LIGHT} Unable to find the data for key \"{key_name}\" when looking up metric \"{full_key_path}\" in collated opmon data. \N{POLICE CARS REVOLVING LIGHT}")
+            return False
+
+        # sanity check - make sure that we really have a dictionary at the next level in the tree
+        if not isinstance(working_dict, dict):
+            print(f"\N{POLICE CARS REVOLVING LIGHT} The data type of the opmon data associated with the '{key_name}' key ({type(working_dict)}) is not 'dictionary', as it needs to be. \N{POLICE CARS REVOLVING LIGHT}")
+            return False
+
+    value_sum = 0;
+    for timestamp_string in working_dict.keys():
+        value_sum += int(working_dict[timestamp_string])
+    if max_value_sum == -1:
+        if value_sum < min_value_sum:
+            print(f"\N{POLICE CARS REVOLVING LIGHT} The sum of metric values for key \"{full_key_path}\" ({value_sum}) is outside the expected range ({min_value_sum}..unbounded). \N{POLICE CARS REVOLVING LIGHT}")
+            return False
+        else:
+            print(f"\N{WHITE HEAVY CHECK MARK} The sum of metric values for key \"{full_key_path}\" ({value_sum}) is within the expected range ({min_value_sum}..unbounded). \N{WHITE HEAVY CHECK MARK}")
+            return True
+    else:
+        if value_sum < min_value_sum or value_sum > max_value_sum:
+            print(f"\N{POLICE CARS REVOLVING LIGHT} The sum of metric values for key \"{full_key_path}\" ({value_sum}) is outside the expected range ({min_value_sum}..{max_value_sum}). \N{POLICE CARS REVOLVING LIGHT}")
+            return False
+        else:
+            print(f"\N{WHITE HEAVY CHECK MARK} The sum of metric values for key \"{full_key_path}\" ({value_sum}) is within the expected range ({min_value_sum}..{max_value_sum}). \N{WHITE HEAVY CHECK MARK}")
+            return True

--- a/src/integrationtest/opmon_metric_checks.py
+++ b/src/integrationtest/opmon_metric_checks.py
@@ -57,14 +57,14 @@ def check_metric_sample_count(collated_opmon_data: dict, dict_key_list: list, mi
             print(f"\N{POLICE CARS REVOLVING LIGHT} The number of metric samples for key \"{full_key_path}\" ({number_of_samples}) is outside the expected range ({min_count}..unbounded). \N{POLICE CARS REVOLVING LIGHT}")
             return False
         else:
-            print(f"\N{WHITE HEAVY CHECK MARK} The number of metric samples for key \"{full_key_path}\" ({number_of_samples}) is within the expected range ({min_count}..unbounded). \N{WHITE HEAVY CHECK MARK}")
+            print(f"\N{WHITE HEAVY CHECK MARK} The number of metric samples for key \"{full_key_path}\" ({number_of_samples}) is within the expected range ({min_count}..unbounded).")
             return True
     else:
         if number_of_samples < min_count or number_of_samples > max_count:
             print(f"\N{POLICE CARS REVOLVING LIGHT} The number of metric samples for key \"{full_key_path}\" ({number_of_samples}) is outside the expected range ({min_count}..{max_count}). \N{POLICE CARS REVOLVING LIGHT}")
             return False
         else:
-            print(f"\N{WHITE HEAVY CHECK MARK} The number of metric samples for key \"{full_key_path}\" ({number_of_samples}) is within the expected range ({min_count}..{max_count}). \N{WHITE HEAVY CHECK MARK}")
+            print(f"\N{WHITE HEAVY CHECK MARK} The number of metric samples for key \"{full_key_path}\" ({number_of_samples}) is within the expected range ({min_count}..{max_count}).")
             return True
 
 
@@ -117,12 +117,12 @@ def check_metric_value_sum(collated_opmon_data: dict, dict_key_list: list, min_v
             print(f"\N{POLICE CARS REVOLVING LIGHT} The sum of metric values for key \"{full_key_path}\" ({value_sum}) is outside the expected range ({min_value_sum}..unbounded). \N{POLICE CARS REVOLVING LIGHT}")
             return False
         else:
-            print(f"\N{WHITE HEAVY CHECK MARK} The sum of metric values for key \"{full_key_path}\" ({value_sum}) is within the expected range ({min_value_sum}..unbounded). \N{WHITE HEAVY CHECK MARK}")
+            print(f"\N{WHITE HEAVY CHECK MARK} The sum of metric values for key \"{full_key_path}\" ({value_sum}) is within the expected range ({min_value_sum}..unbounded).")
             return True
     else:
         if value_sum < min_value_sum or value_sum > max_value_sum:
             print(f"\N{POLICE CARS REVOLVING LIGHT} The sum of metric values for key \"{full_key_path}\" ({value_sum}) is outside the expected range ({min_value_sum}..{max_value_sum}). \N{POLICE CARS REVOLVING LIGHT}")
             return False
         else:
-            print(f"\N{WHITE HEAVY CHECK MARK} The sum of metric values for key \"{full_key_path}\" ({value_sum}) is within the expected range ({min_value_sum}..{max_value_sum}). \N{WHITE HEAVY CHECK MARK}")
+            print(f"\N{WHITE HEAVY CHECK MARK} The sum of metric values for key \"{full_key_path}\" ({value_sum}) is within the expected range ({min_value_sum}..{max_value_sum}).")
             return True


### PR DESCRIPTION
# Description

These changes are for `fddaq-v5.6.0`... 

As part of adding the validation of opmon metrics to integtests (DUNE-DAQ/daq-deliverables#202), I created several utility functions in a new file named `opmon_metric_checks.py`.  There is a function to collate a set of metric files on disk into a single JSON structure and a couple of validation functions - one to check whether the number of metric samples is within a specified range and one to check whether the sum of the metric values is within a specified range.

These changes also include a bug fix - the directory glob to find the metric files produced in an integtest needed to be adjusted.

The way to test these changes is to run the modified regression tests in the `daqsystemtest` repo (which are part of a correlated PR).

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
