### PR TITLE
Added a DAQ session overall time measurement to the integrationtest results…

### DIFF
--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -431,6 +431,7 @@ def run_nanorc(request, create_config_files, tmp_path_factory):
         "++++++++++ DRUNC Run BEGIN ++++++++++", flush=True
     )  # Apparently need to flush before subprocess.run
     result = RunResult()
+    time_before = time.time()
     result.completed_process = subprocess.run(
         [nanorc]
         + nanorc_option_strings
@@ -441,6 +442,7 @@ def run_nanorc(request, create_config_files, tmp_path_factory):
         + command_list,
         cwd=run_dir,
     )
+    time_after = time.time()
 
     if connsvc_obj is not None:
         time.sleep(1)
@@ -480,5 +482,8 @@ def run_nanorc(request, create_config_files, tmp_path_factory):
         )
     result.log_files = list(run_dir.glob("log_*.txt")) + list(run_dir.glob("log_*.log"))
     result.opmon_files = list(run_dir.glob(f"info*{result.session_name if result.session_name else result.session}*.json"))
+    # 10-Dec-2025, KAB: added the DAQ session overall time so that we can use this
+    # information in fine-tuning the allowed ranges in time-based checking of test results.
+    result.daq_session_overall_time = time_after - time_before
     print("---------- DRUNC Run END ----------", flush=True)
     yield result


### PR DESCRIPTION
…that are passed back to users so that it can be used for fine-tuning ranges in various time-based checks on the results of the test.

# Description

This PR is correlated with a PR in the `daqsystemtest` repo, specifically DUNE-DAQ/daqsystemtest#276.

The changes in this repo are rather straightforward: measuring the overall wallclock time that is spent running the DAQ session and passing that value back to the user in the RunResults structure.  

This change was prompted by a recent failure in the number-of-metric-samples validation check in `daqsystemtest/minimal_system_quick_test.sh`.  Instead of an expected 3 metric samples in that test, 6 metric samples were observed.  The extra samples were caused by a longer-than-normal run time of the DAQ session.  (I'm not sure which DAQ transition took longer than normal, nor why that may have happened.)

Here are suggestions for testing these changes in conjunction with the ones in `daqsystemtest`:
```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_251211_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/handle_extra_metric_samples
cd ..

dbt-workarea-env

git clone https://github.com/DUNE-DAQ/integrationtest.git -b kbiery/session_time_bundle_info
cd integrationtest; pip install -U . ; cd ..

dbt-build -j 12
dbt-workarea-env

daqsystemtest_integtest_bundle.sh -k minimal
echo ""
echo -e "\U1F535 \U2705 Note that the previous regression test succeeded. \U2705 \U1F535"
echo -e "\U1F535 \U2705 In particular, the metric sample check was successful. \U2705 \U1F535"
echo ""

sed -i 's,boot conf start,boot conf wait 35 start,' sourcecode/daqsystemtest/integtest/minimal_system_quick_test.py

daqsystemtest_integtest_bundle.sh -k minimal
echo ""
echo -e "\U1F535 \U2705 Note that the previous regression test succeeded, even though \U2705 \U1F535"
echo -e "\U1F535 \U2705 the number of metric samples fluctuation upward from 3 to 6. \U2705 \U1F535"

```

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
