### PR TITLE
Added get_pytest_tmpdir.py to determine the root of the current pytest tmpdir

### DIFF
--- a/src/integrationtest/get_pytest_tmpdir.py
+++ b/src/integrationtest/get_pytest_tmpdir.py
@@ -1,12 +1,19 @@
 # 30-Dec-2025, KAB: this function determines the root of the current pytest output
 # directory (i.e. the current pytest "tmpdir"). It does this by checking the relevant
 # environmental variables to see if any of them have been set.
+#
 # The order in which the env vars are checked is based on the precedence that the
 # pytest framework uses.
+#
+# A useful reference is here:
+# https://docs.pytest.org/en/stable/how-to/tmp_path.html#temporary-directory-location-and-retention
+#
 # If none of the relevent env vars have been set, this functions returns "/tmp"
 # which is the current default for the pytest output root directory.
+#
 # This function will initially be used in our integtest (python) files and in
 # our integtest bundle script(s).
+#
 import os
 def get_pytest_tmpdir():
     tmpdir = os.environ.get("PYTEST_DEBUG_TEMPROOT")

--- a/src/integrationtest/get_pytest_tmpdir.py
+++ b/src/integrationtest/get_pytest_tmpdir.py
@@ -1,0 +1,24 @@
+# 30-Dec-2025, KAB: this function determines the root of the current pytest output
+# directory (i.e. the current pytest "tmpdir"). It does this by checking the relevant
+# environmental variables to see if any of them have been set.
+# The order in which the env vars are checked is based on the precedence that the
+# pytest framework uses.
+# If none of the relevent env vars have been set, this functions returns "/tmp"
+# which is the current default for the pytest output root directory.
+# This function will initially be used in our integtest (python) files and in
+# our integtest bundle script(s).
+import os
+def get_pytest_tmpdir():
+    tmpdir = os.environ.get("PYTEST_DEBUG_TEMPROOT")
+    if tmpdir:
+        return tmpdir
+    tmpdir = os.environ.get("TMPDIR")
+    if tmpdir:
+        return tmpdir
+    tmpdir = os.environ.get("TEMP")
+    if tmpdir:
+        return tmpdir
+    tmpdir = os.environ.get("TMP")
+    if tmpdir:
+        return tmpdir
+    return "/tmp"


### PR DESCRIPTION
# Description

This PR is correlated with DUNE-DAQ/daqsystemtest#282.

This PR adds a Python function which provides a central location for determining the current pytest tmpdir based on any relevant environmental variables that are set.  This is useful in our integtest bundle scripts and in the integtests themselves.

Please see the suggestions in the `daqsystemtest` PR for testing.

Also, please see the `daqsystemtest` PR for background information on the logic that is used in this new function.

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
