### PR TITLE
Removed the import of the deprecated pkg_resources package from integrationtest_drunc.py.

### DIFF
--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -3,7 +3,6 @@ import subprocess
 import pathlib
 import getpass
 import os
-import pkg_resources
 import conffwk
 from integrationtest.integrationtest_commandline import file_exists
 from integrationtest.data_classes import (


### PR DESCRIPTION
# Description

While running some tests with `externals v2.3` (specifically, with nightly build `EXTFD_DEV_260115_A9`), I noticed that the following warning message was being printed out at the end of each integrationt test:

```
=============================== warnings summary ===============================
.venv/lib/python3.12/site-packages/integrationtest/integrationtest_drunc.py:6
  /home/nfs/biery/dunedaq/17JanFDDevExternals2.3Testing/.venv/lib/python3.12/site-packages/integrationtest/integrationtest_drunc.py:6: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
    import pkg_resources
```

I believe that the change in this PR gets rid of that warning message and doesn't have any negative effects.  I've run `dbt-build --integtest` on 5 of the 8 packages that have integtests, and they all ran fine.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
