### PR TITLE
Introduce --skip-resource-checks parameter

### DIFF
--- a/src/integrationtest/integrationtest_commandline.py
+++ b/src/integrationtest/integrationtest_commandline.py
@@ -28,6 +28,13 @@ def pytest_addoption(parser):
         help="Whether to disable the Connectivity Service for this test",
         required=False
     )
+    parser.addoption(
+        "--skip-resource-checks",
+        action="store_true",
+        default=False,
+        help="Whether to skip the node resource (CPU/Memory) checks for this test",
+        required=False
+    )
 
 def pytest_configure(config):
     for opt in ("--nanorc-path",):

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -5,6 +5,7 @@ import getpass
 import os
 import conffwk
 from integrationtest.integrationtest_commandline import file_exists
+from integrationtest.resource_validation import ResourceValidator
 from integrationtest.data_classes import (
     CreateConfigResult,
     ProcessManagerChoice,
@@ -89,7 +90,31 @@ def process_manager_type(request, tmp_path_factory):
     yield result
 
 @pytest.fixture(scope="module")
-def create_config_files(request, tmp_path_factory):
+def check_system_resources(request):
+    """Check that the system resources (CPU, Memory) are sufficient for the test
+    The required and recommended resources are taken from the
+    `resource_validator` variable in the global scope of the test
+    module, which should be an instance of ResourceValidator. If the
+    required resources are not present, then the test is skipped. If
+    the recommended resources are not present, then a warning is printed
+    """
+    skip_resource_checks = request.config.getoption("--skip-resource-checks")
+
+    resval = getattr(request.module, "resource_validator", ResourceValidator())
+    if not resval.required_resources_are_present:
+        resval_report_string = resval.get_required_resources_report()
+        print(f"\n\N{LARGE YELLOW CIRCLE} {resval_report_string}")
+        resval_summary_string = resval.get_required_resources_summary()
+        if not skip_resource_checks:
+            pytest.skip(f"{resval_summary_string}")
+    if not resval.recommended_resources_are_present:
+        resval_report_string = resval.get_recommended_resources_report()
+        print(f"\n*** Note: {resval_report_string}")
+
+    yield True
+
+@pytest.fixture(scope="module")
+def create_config_files(request, tmp_path_factory, check_system_resources):
     """Run the confgen to produce the configuration json files
 
     The name of the module to use is taken (indirectly) from the
@@ -101,10 +126,14 @@ def create_config_files(request, tmp_path_factory):
     produced by one pytest module
 
     """
+    dummy_resource_check = check_system_resources
     drunc_config = request.param
 
     disable_connectivity_service = request.config.getoption(
         "--disable-connectivity-service"
+    )
+    skip_resource_checks = request.config.getoption(
+        "--skip-resource-checks"
     )
 
     config_dir = tmp_path_factory.mktemp("config")

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -104,14 +104,22 @@ def check_system_resources(request):
     if not resval.required_resources_are_present:
         resval_report_string = resval.get_required_resources_report()
         print(f"\n\N{LARGE YELLOW CIRCLE} {resval_report_string}")
-        resval_summary_string = resval.get_required_resources_summary()
         if not skip_resource_checks:
-            pytest.skip(f"{resval_summary_string}")
+            # 16-Feb-2026, KAB: discard all of the test items except the
+            # first one so that we only get one "skip" output message.
+            del request.session.items[1:]
+            pytest.skip(f"\n\N{LARGE YELLOW CIRCLE} {resval_report_string}")
     if not resval.recommended_resources_are_present:
         resval_report_string = resval.get_recommended_resources_report()
         print(f"\n*** Note: {resval_report_string}")
 
     yield True
+
+    # 16-Feb-2026, KAB: added a printout for recommended resources after the "yield"
+    # statement so that it gets printed out at the end of the output that the user sees.
+    if not resval.recommended_resources_are_present:
+        resval_report_string = resval.get_recommended_resources_report()
+        print(f"\n*** Note: {resval_report_string}")
 
 @pytest.fixture(scope="module")
 def create_config_files(request, tmp_path_factory, check_system_resources):

--- a/src/integrationtest/resource_validation.py
+++ b/src/integrationtest/resource_validation.py
@@ -15,21 +15,14 @@
 # Here is pseudo-code for using this utility:
 #
 # import integrationtest.resource_validation as resource_validation
-# resval = resource_validation.ResourceValidator()
-# resval.cpu_count_needs(32, 64)
-# resval.free_memory_needs(28)
+# # MUST be named "resource_validator"
+# resource_validator = resource_validation.ResourceValidator()
+# resource_validator.cpu_count_needs(32, 64)
+# resource_validator.free_memory_needs(28)
 # # set other minimum values, if desired
-# resval_debug_string = resval.get_debug_string()
+# resval_debug_string = resource_validator.get_debug_string()
 # print(f"{resval_debug_string}")
-# # then, in one of the pytest "tests"
-# if not resval.required_resources_are_present
-#     resval_full_report = resval.get_required_resources_report()
-#     print(f"{resval_full_report}")
-#     resval_summary_report = resval.get_required_resources_summary()
-#     pytest.skip(f"{resval_summary_report}")
-# if not resval.recommended_resources_are_present
-#     resval_full_report = resval.get_recommended_resources_report()
-#     print(f"{resval_full_report}")
+# # The check_system_resources fixture will check that the system has the required resources
 
 import os
 import psutil
@@ -181,6 +174,52 @@ class ResourceValidator:
             if len(self.recommended_resource_report_string) == 0:
                 self.recommended_resource_report_string = self.recommended_resource_report_header
             self.recommended_resource_report_string += f"\n{self.report_indentation} Total disk space on \"{path_of_interest}\" is {total_disk_space_gb} GB, recommended amount is {recommended_total_disk_space}."
+
+    # method to specify the regular expression which the hostname should match
+    def require_host_match(self, required_host_regex):
+        hostname = os.uname().nodename
+        self.debug_string += f"\nDEBUG: Hostname is \"{hostname}\", required regex is \"{required_host_regex}\""
+        if not re.match(required_host_regex, hostname):
+            self.this_computer_has_sufficient_resources = False
+            self.required_resources_are_present = False
+            if len(self.required_resource_report_string) == 0:
+                self.required_resource_report_string = self.required_resource_report_header
+            self.required_resource_report_string += f"\n{self.report_indentation} Hostname is \"{hostname}\", which does not match the required regex \"{required_host_regex}\"."
+
+    # method to check connectivity to certain hosts
+    def require_host_connectivity(self, required_host_list):
+        # Set up the software environment on each of the 4 computers needed for this test.
+        # This serves two purposes: it verifies that we can ssh to
+        # those computers (so we know that we are running at EHN1, etc.), and it pre-loads
+        # the software release from CVMFS onto all of those computers (so the startup of
+        # DAQ apps such as the ConnectivityServer don't take a long time initially).
+        import subprocess
+        computers_that_are_unreachable = []
+        sw_area_root = os.environ.get("DBT_AREA_ROOT")
+        if sw_area_root is not None:
+            for needed_computer in required_host_list:
+                print("")
+                print(f"Confirming that we can ssh to {needed_computer}...")
+                proc = subprocess.Popen(f"ssh {needed_computer} 'cd {sw_area_root}; . ./env.sh'", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                proc.communicate()
+                retval = proc.returncode
+                if retval != 0:
+                    computers_that_are_unreachable.append(needed_computer)
+        else:
+            self.debug_string += "\nDEBUG: DBT_AREA_ROOT environment variable is not set, so connectivity checks were not performed."
+            self.this_computer_has_sufficient_resources = False
+            self.required_resources_are_present = False
+            if len(self.required_resource_report_string) == 0:
+                self.required_resource_report_string = self.required_resource_report_header
+            self.required_resource_report_string += f"\n{self.report_indentation} Unable to determine the value of the DBT_AREA_ROOT env var."
+
+        if len(computers_that_are_unreachable) > 0:
+            self.this_computer_has_sufficient_resources = False
+            self.required_resources_are_present = False
+            if len(self.required_resource_report_string) == 0:
+                self.required_resource_report_string = self.required_resource_report_header
+            for unreachable_computer in computers_that_are_unreachable:
+                self.required_resource_report_string += f"\n{self.report_indentation} Unable to ssh to {unreachable_computer}."
 
     def get_debug_string(self):
         return self.debug_string


### PR DESCRIPTION
# Description

Implement resource checking and test skipping as a fixture required before generating a configuration.
With this set of changes, tests specify their recommended and required system resources via a "resource_validator" object, which the check_system_resources fixture uses to determine if sufficient resources are present on the system. The user can, however, pass the --skip-resource-checks parameter to pytest, forcing the tests to run regardless.

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

On a virtual machine with dynamic memory (so the free memory is always a low value):
daqsystemtest_integtest_bundle.sh
```
...
🔵 Starting test 9 of 9... 🔵
⮕ Running example_system_test.py ⬅
============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/eflumerf/Desktop/dune-daq-base/dev-recommendedspecs-260213/sourcecode/daqsystemtest
configfile: pytest.ini
plugins: anyio-4.12.1, integrationtest-3.6.0

DEBUG: CPU count is 32, required number is 30, recommended number is 60
DEBUG: Free memory is 1.25 GB, required amount is 15, recommended amount is 24
DEBUG: Free disk space on "/tmp" is 65.87333679199219 GB, required amount is 1
collected 6 items

sourcecode/daqsystemtest/integtest/example_system_test.py
🟡 This computer (ironvirt9) does not have enough resources to run this test.
 * Free memory is 1.25 GB, required amount is 15.
ssssss

============================== 6 skipped in 0.35s ==============================


+++++++++++++++++++++++++++++++++++++++++++++++++
++++++++++++++++++++ SUMMARY ++++++++++++++++++++
+++++++++++++++++++++++++++++++++++++++++++++++++

Fri Feb 13 03:35:49 PM CST 2026
Log file is: /tmp/pytest-of-eflumerf/daqsystemtest_integtest_bundle_20260213153542.log

⮕ Running minimal_system_quick_test.py ⬅
============================== 4 skipped 🟡 in 1.01s ==============================
⮕ Running readout_type_scan_test.py ⬅
============================= 27 skipped 🟡 in 0.36s ==============================
⮕ Running 3ru_3df_multirun_test.py ⬅
============================== 6 skipped 🟡 in 0.35s ==============================
⮕ Running small_footprint_quick_test.py ⬅
============================== 3 skipped 🟡 in 0.35s ==============================
⮕ Running fake_data_producer_test.py ⬅
============================== 6 skipped 🟡 in 0.35s ==============================
⮕ Running long_window_readout_test.py ⬅
============================== 4 skipped 🟡 in 0.33s ==============================
⮕ Running 3ru_1df_multirun_test.py ⬅
============================== 6 skipped 🟡 in 0.37s ==============================
⮕ Running tpstream_writing_test.py ⬅
============================== 4 skipped 🟡 in 0.38s ==============================
⮕ Running example_system_test.py ⬅
============================== 6 skipped 🟡 in 0.35s ==============================
```

daqsystemtest_integtest_bundle.sh --skip-resource-checks -f0 -l0
```
...
========================= 4 passed in 60.89s (0:01:00) =========================


+++++++++++++++++++++++++++++++++++++++++++++++++
++++++++++++++++++++ SUMMARY ++++++++++++++++++++
+++++++++++++++++++++++++++++++++++++++++++++++++

Fri Feb 13 03:37:56 PM CST 2026
Log file is: /tmp/pytest-of-eflumerf/daqsystemtest_integtest_bundle_20260213153654.log

⮕ Running minimal_system_quick_test.py ⬅
========================= 4 passed ✅ in 60.89s (0:01:00) =========================
((dbt) ) [eflumerf@ironvirt9 dev-recommendedspecs-260213]$
```