### PR TITLE
Modified integrationtest_drunc.py to print out more information…

### DIFF
--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -104,14 +104,22 @@ def check_system_resources(request):
     if not resval.required_resources_are_present:
         resval_report_string = resval.get_required_resources_report()
         print(f"\n\N{LARGE YELLOW CIRCLE} {resval_report_string}")
-        resval_summary_string = resval.get_required_resources_summary()
         if not skip_resource_checks:
-            pytest.skip(f"{resval_summary_string}")
+            # 16-Feb-2026, KAB: discard all of the test items except the
+            # first one so that we only get one "skip" output message.
+            del request.session.items[1:]
+            pytest.skip(f"\n\N{LARGE YELLOW CIRCLE} {resval_report_string}")
     if not resval.recommended_resources_are_present:
         resval_report_string = resval.get_recommended_resources_report()
         print(f"\n*** Note: {resval_report_string}")
 
     yield True
+
+    # 16-Feb-2026, KAB: added a printout for recommended resources after the "yield"
+    # statement so that it gets printed out at the end of the output that the user sees.
+    if not resval.recommended_resources_are_present:
+        resval_report_string = resval.get_recommended_resources_report()
+        print(f"\n*** Note: {resval_report_string}")
 
 @pytest.fixture(scope="module")
 def create_config_files(request, tmp_path_factory, check_system_resources):


### PR DESCRIPTION
… when required or recommended computer resources are  not available.

# Description

These changes are minor tweaks to the changes that Eric made in #144.  They are based on Eric's branch, and they are related to DUNE-DAQ/daqsystemtest#294.

Eric, 
I liked the spirit of your changes.

Two things that I felt were lost (and I would like to get back) were

- printout of the `required_resources_report` when a test is skipped and the `--concise` option is passed to the bundle script or the "-s" option is not given to `pytest` itself
- printout of the `recommended_resources_report` at the end of the console output from a test (so that users don't have to scroll back to see it)

In the first case, I made modifications in this repo and in the `dunedaq_integtest_bundle.sh` script to recover the message when `--concise` is used.  I don't yet have a solution for the case when a user runs `pytest` directly and omits the "-s".

For the second case, I just added a second printout of `recommended_resources_report` after the "yield" in `check_system_resources`.

Another change that I felt would be useful was to switch from using a `--skip-resource-check` option in the bundle script to using a `--pytest-options` option.  I know of an additional option that would be nice to pass to pytest (the process manager type), and it seems reasonable to simply give users a hook to pass all the options that they want to pass through the bundle script instead of trying to add support for each one. This change is in the `daqsystemtest` repo.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
