### PR TITLE
Support raw data filenames without timestamps in data_file_checks

### DIFF
--- a/src/integrationtest/data_file_checks.py
+++ b/src/integrationtest/data_file_checks.py
@@ -115,6 +115,7 @@ def check_file_attributes(datafile, was_test_run="true"):
                     passed=False
                     print(f"\N{POLICE CARS REVOLVING LIGHT} The value in HDF5 File Attribute '{expected_attr_name}' ({attr_value}) does not match the value in the filename ({base_filename}) \N{POLICE CARS REVOLVING LIGHT}")
         elif expected_attr_name == "creation_timestamp":
+            # value from the Attribute (with a little bit of variation allowed)
             attr_value = datafile.h5file.attrs.get(expected_attr_name)
             date_obj = datetime.datetime.fromtimestamp((int(attr_value)/1000)-1, datetime.timezone.utc)
             date_string = date_obj.strftime("%Y%m%dT%H%M%S")
@@ -125,10 +126,17 @@ def check_file_attributes(datafile, was_test_run="true"):
             date_obj = datetime.datetime.fromtimestamp((int(attr_value)/1000)+0, datetime.timezone.utc)
             date_string = date_obj.strftime("%Y%m%dT%H%M%S")
             pattern_exact = f".*{date_string}.*"
-            if not re.match(pattern_exact, base_filename) and not re.match(pattern_low, base_filename) and not re.match(pattern_high, base_filename):
-                passed=False
-                print(f"\N{POLICE CARS REVOLVING LIGHT} The value in HDF5 File Attribute '{expected_attr_name}' ({date_string}) does not match the value in the filename ({base_filename}) \N{POLICE CARS REVOLVING LIGHT}")
-                print(f"\N{POLICE CARS REVOLVING LIGHT} Debug information: pattern_low={pattern_low} pattern_high={pattern_high} pattern_exact={pattern_exact} \N{POLICE CARS REVOLVING LIGHT}")
+            # 05-Feb-2026, KAB: added code to check if the unique substring based on the current date/time
+            # exists in the filename exists before we do any checking.
+            # value from the filename
+            pattern = r"_\d+T\d+"
+            match_obj = re.search(pattern, base_filename)
+            if match_obj:
+                filename_value = re.sub('_','',match_obj.group(0))
+                if not re.match(pattern_exact, filename_value) and not re.match(pattern_low, filename_value) and not re.match(pattern_high, filename_value):
+                    passed=False
+                    print(f"\N{POLICE CARS REVOLVING LIGHT} The value in HDF5 File Attribute '{expected_attr_name}' ({date_string}) does not match the value in the filename ({base_filename}) \N{POLICE CARS REVOLVING LIGHT}")
+                    print(f"\N{POLICE CARS REVOLVING LIGHT} Debug information: pattern_low={pattern_low} pattern_high={pattern_high} pattern_exact={pattern_exact} filename_value={filename_value} \N{POLICE CARS REVOLVING LIGHT}")
         elif expected_attr_name == "run_was_for_test_purposes":
             # value from the Attribute
             attr_value = datafile.h5file.attrs.get(expected_attr_name)

--- a/src/integrationtest/data_file_checks.py
+++ b/src/integrationtest/data_file_checks.py
@@ -128,7 +128,6 @@ def check_file_attributes(datafile, was_test_run="true"):
             pattern_exact = f".*{date_string}.*"
             # 05-Feb-2026, KAB: added code to check if the unique substring based on the current date/time
             # exists in the filename exists before we do any checking.
-            # value from the filename
             pattern = r"_\d+T\d+"
             match_obj = re.search(pattern, base_filename)
             if match_obj:


### PR DESCRIPTION
# Description

When doing various testing, I noticed that the existing logic in the integration test data-file-check code will give a false alarm about mismatched timestamps when raw data filenames don't have dates in them.  The changes in this PR take filenames without dates into account.

Here are suggested steps for validating the changes:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260219_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
cd ..

dbt-workarea-env

cd pythoncode
git clone https://github.com/DUNE-DAQ/integrationtest.git -b develop
pip install integrationtest/.
cd ..

dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -k min

echo ""
echo -e "\U1F535 \U2705 Everything works fine when raw data filenames have dates in them. \U2705 \U1F535"
echo ""
echo ""
sleep 3

cd sourcecode/daqsystemtest/config/daqsystemtest
sed -i 's,<attr name="disable_unique_filename_suffix" type="bool" val="0"/>,<attr name="disable_unique_filename_suffix" type="bool" val="1"/>,' moduleconfs.data.xml
cd ../../../../

dbt-workarea-env

dunedaq_integtest_bundle.sh -k min

echo ""
echo -e "\U1F535 \U2705 Note that the MSQT test fails because of a mismatch in the dates in the filename and the HDF5 file Attribute, when the raw data filename doesn't have a date in it. \U2705 \U1F535"
echo ""
echo ""
sleep 3

cd pythoncode/integrationtest
git checkout kbiery/support_filenames_without_timestamps
pip install .
cd ../../

dbt-workarea-env

dunedaq_integtest_bundle.sh -k min

echo ""
echo -e "\U1F535 \U2705 Note that the MSQT test no longer fails, with the new integrationtest code. \U2705 \U1F535"
echo ""
echo ""
```



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
