### PR TITLE
initial changes to replace the nanorc name with a more generic 'dunerc' name

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ pytest -s test_integration.py
 
 The test framework handles running python with the confgen specified in the test file, then runs drunc with the generated OKS database (a copy of the database is always made to prevent accidental changes). Finally, the actual test functions are run.
 
-(The framework searches for the `drunc-unified-shell` script in `$PATH`. If you want to use a different run control implementation from elsewhere, you can use the `--nanorc-path` argument to point the test to the script).
+(The framework searches for the `drunc-unified-shell` script in `$PATH`. If you want to use a different run control implementation from elsewhere, you can use the `--dunerc-path` argument to point the test to the script).
 
 ## Writing test functions
 

--- a/src/integrationtest/integrationtest_commandline.py
+++ b/src/integrationtest/integrationtest_commandline.py
@@ -7,18 +7,18 @@ def file_exists(s):
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--nanorc-path",
+        "--dunerc-path",
         action="store",
         type=pathlib.Path,
         default=None,
-        help="Path to nanorc. Default is to search in $PATH",
+        help="Path to DUNE run control. Default is to search in $PATH",
         required=False
     )
     parser.addoption(
-        "--nanorc-option",
+        "--dunerc-option",
         action="append",
         nargs="+",
-        help="Repeatable, nanorc arguments without leading dashes (e.g. kerberos)",
+        help="Repeatable, DUNE run control arguments without leading dashes (e.g. kerberos)",
         required=False
     )
     parser.addoption(
@@ -37,7 +37,7 @@ def pytest_addoption(parser):
     )
 
 def pytest_configure(config):
-    for opt in ("--nanorc-path",):
+    for opt in ("--dunerc-path",):
         p=config.getoption(opt)
         if p is not None and not file_exists(p):
             pytest.exit(f"{opt} path {p} is not an existing file")

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -62,8 +62,8 @@ def parametrize_fixture_with_items(metafunc, fixture, itemsname):
 
 
 def pytest_generate_tests(metafunc):
-    # We want to be able to run multiple confgens and multiple nanorcs
-    # from one pytest module, but the fixtures for running the
+    # We want to be able to run multiple confgens and multiple DAQ
+    # sessions from one pytest module, but the fixtures for running the
     # external commands are module-scoped, so we need to parametrize
     # the fixtures. This could be done by adding "params=..." to the
     # @pytest.fixture decorator at each fixture, but the user doesn't
@@ -76,9 +76,18 @@ def pytest_generate_tests(metafunc):
     if not hasattr(metafunc.module, "process_manager_choices"):
         metafunc.module.process_manager_choices = { "StandAloneSSH_PM" : {"pm_type": "ssh-standalone"} }
 
+    # 27-Feb-2026, KAB: support for the nanorc --> dunerc transition
+    if not hasattr(metafunc.module, "dunerc_command_list") and hasattr(metafunc.module, "nanorc_command_list"):
+        metafunc.module.dunerc_command_list = metafunc.module.nanorc_command_list
+
     parametrize_fixture_with_items(metafunc, "create_config_files", "confgen_arguments")
     parametrize_fixture_with_items(metafunc, "process_manager_type", "process_manager_choices")
-    parametrize_fixture_with_items(metafunc, "run_nanorc", "nanorc_command_list")
+
+    # 27-Feb-2026, KAB: support for the nanorc --> dunerc transition
+    if "run_nanorc" in metafunc.fixturenames:
+        parametrize_fixture_with_items(metafunc, "run_nanorc", "dunerc_command_list")
+    if "run_dunerc" in metafunc.fixturenames:
+        parametrize_fixture_with_items(metafunc, "run_dunerc", "dunerc_command_list")
 
 
 # 29-Dec-2025, KAB: added fixture to handle different process manager choices
@@ -345,11 +354,15 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
 
 
 @pytest.fixture(scope="module")
-def run_nanorc(request, create_config_files, process_manager_type, tmp_path_factory):
-    """Run nanorc with the OKS DB files created by `create_config_files`. The
-    commands specified by the `nanorc_command_list` variable in the
-    test module are executed. If `nanorc_command_list`'s items are
-    themselves lists, then nanorc will be run multiple times, once for
+def run_nanorc(run_dunerc):
+    yield run_dunerc
+
+@pytest.fixture(scope="module")
+def run_dunerc(request, create_config_files, process_manager_type, tmp_path_factory):
+    """Run drunc with the OKS DB files created by `create_config_files`. The
+    commands specified by the `dunerc_command_list` variable in the
+    test module are executed. If `dunerc_command_list`'s items are
+    themselves lists, then drunc will be run multiple times, once for
     each set of arguments in the list
 
     """
@@ -418,22 +431,22 @@ def run_nanorc(request, create_config_files, process_manager_type, tmp_path_fact
             env=connsvc_env,
         )
 
-    nanorc = request.config.getoption("--nanorc-path")
-    if nanorc is None:
-        nanorc = "drunc-unified-shell"
-    nanorc_options = request.config.getoption("--nanorc-option")
-    nanorc_option_strings = []
-    if nanorc_options is not None:
-        for opt in nanorc_options:
+    dunerc = request.config.getoption("--dunerc-path")
+    if dunerc is None:
+        dunerc = "drunc-unified-shell"
+    dunerc_options = request.config.getoption("--dunerc-option")
+    dunerc_option_strings = []
+    if dunerc_options is not None:
+        for opt in dunerc_options:
             if len(opt) > 2:
-                print("Nanorc options take either 0 or 1 arguments!")
+                print("dunerc options take either 0 or 1 arguments!")
                 pytest.fail()
             if len(opt[0]) == 1:
-                nanorc_option_strings.append("-" + "".join(opt))
+                dunerc_option_strings.append("-" + "".join(opt))
             else:
-                nanorc_option_strings.append("--" + opt[0])
+                dunerc_option_strings.append("--" + opt[0])
                 if len(opt) == 2:
-                    nanorc_option_strings.append(opt[1])
+                    dunerc_option_strings.append(opt[1])
 
     class RunResult:
         pass
@@ -513,8 +526,8 @@ def run_nanorc(request, create_config_files, process_manager_type, tmp_path_fact
     result = RunResult()
     time_before = time.time()
     result.completed_process = subprocess.run(
-        [nanorc]
-        + nanorc_option_strings
+        [dunerc]
+        + dunerc_option_strings
         + [str(process_manager_type.pm_type)]  # 29-Dec-2025, KAB: support for ProcMgr choices
         + [str(create_config_files.config_file)]
         + [str(create_config_files.config.session)]

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -77,6 +77,8 @@ def pytest_generate_tests(metafunc):
         metafunc.module.process_manager_choices = { "StandAloneSSH_PM" : {"pm_type": "ssh-standalone"} }
 
     # 27-Feb-2026, KAB: support for the nanorc --> dunerc transition
+    # We will be able to remove the following two lines once all integtests
+    # have been converted to use dunerc instead of nanorc.
     if not hasattr(metafunc.module, "dunerc_command_list") and hasattr(metafunc.module, "nanorc_command_list"):
         metafunc.module.dunerc_command_list = metafunc.module.nanorc_command_list
 
@@ -84,6 +86,8 @@ def pytest_generate_tests(metafunc):
     parametrize_fixture_with_items(metafunc, "process_manager_type", "process_manager_choices")
 
     # 27-Feb-2026, KAB: support for the nanorc --> dunerc transition
+    # We will be able to just use "run_dunerc" once all integtests
+    # have been converted to use dunerc instead of nanorc.
     if "run_nanorc" in metafunc.fixturenames:
         parametrize_fixture_with_items(metafunc, "run_nanorc", "dunerc_command_list")
     if "run_dunerc" in metafunc.fixturenames:
@@ -353,6 +357,8 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
     yield result
 
 
+# 27-Feb-2026, KAB: support for the nanorc --> dunerc transition
+# Temporary fixture until all integtests have been changed to use "dunerc".
 @pytest.fixture(scope="module")
 def run_nanorc(run_dunerc):
     yield run_dunerc
@@ -555,7 +561,10 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
     result.confgen_config = create_config_files.config
     result.session = create_config_files.config.session
     result.session_name = create_config_files.config.session_name
+    # 27-Feb-2026, KAB: the nanorc_commands return value can be removed once
+    # all integtests have been changed to use "dunerc".
     result.nanorc_commands = command_list
+    result.dunerc_commands = command_list
     result.run_dir = run_dir
     result.config_dir = create_config_files.config_dir
     result.data_files = []


### PR DESCRIPTION
# Description

As requested in #129 , we would like to replace occurrences of the name "nanorc" with something more generic in our integration tests.

The changes in this PR are a first step in doing that.  These changes replace "nanorc" with "dunerc" in the `integrationtest` infrastructure.  "dunerc" (i.e. "DUNE Run Control") is our current choice for the new name, rather than "drunc", so that it is more generic than the name of the current run control application.

These changes were made in a backward-compatible way.  This means that they can be used by the existing integtests in the various repos.  The backward-compatibility was implemented by keeping a few occurrences of the `nanorc` name around.  We will be able to remove those once all integtests are converted.

Here are suggested instructions for testing these changes.  They demonstrate the successful running of these changes in one integtest that has been converted from "nanorc" to "dunerc" and several that haven't been converted.

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260303_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/listrev.git -b kbiery/nanorc_to_dunerc_name_change
cd ..

cd pythoncode
git clone https://github.com/DUNE-DAQ/integrationtest.git -b kbiery/nanorc_to_dunerc_name_change
cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -r 'daqsystemtest|dfmodules|listrev' -k 'min|tpstream|offline|listrev' --concise

echo ""
echo -e "\U1F535 \U2705 Note that a selection of integtests passed. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
