### PR TITLE
Provide additional ability to specify the run control process manager type for integration tests

### DIFF
--- a/src/integrationtest/data_classes.py
+++ b/src/integrationtest/data_classes.py
@@ -77,9 +77,3 @@ class CreateConfigResult:
     data_dirs: list[str]
     tpstream_data_dirs: list[str]
     trmon_data_dirs: list[str]
-
-
-# 29-Dec-2025, KAB: added support for different run control process managers
-@dataclass
-class ProcessManagerChoice:
-    pm_type: str

--- a/src/integrationtest/integrationtest_commandline.py
+++ b/src/integrationtest/integrationtest_commandline.py
@@ -35,6 +35,13 @@ def pytest_addoption(parser):
         help="Whether to skip the node resource (CPU/Memory) checks for this test",
         required=False
     )
+    parser.addoption(
+        "--process-manager-type",
+        action="store",
+        default="",
+        help="The run control process manager type to use for this test, e.g. ssh-standalone",
+        required=False
+    )
 
 def pytest_configure(config):
     for opt in ("--nanorc-path",):

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -8,7 +8,6 @@ from integrationtest.integrationtest_commandline import file_exists
 from integrationtest.resource_validation import ResourceValidator
 from integrationtest.data_classes import (
     CreateConfigResult,
-    ProcessManagerChoice,
     config_substitution,
     attribute_substitution,
     relationship_substitution,
@@ -72,9 +71,35 @@ def pytest_generate_tests(metafunc):
     # and parametrize the fixtures here in pytest_generate_tests,
     # which is run at pytest startup
 
-    # 29-Dec-2025, KAB: added default process manager choice
-    if not hasattr(metafunc.module, "process_manager_choices"):
-        metafunc.module.process_manager_choices = { "StandAloneSSH_PM" : {"pm_type": "ssh-standalone"} }
+
+    # Feb 2026, KAB, Handle run control process manager types...
+    # Choices provided on the command-line, via the --process-manager-type
+    #    option, have the highest priority. The possible values that can be
+    #    specified for this option include a pipe-delimited list of PM types.
+    # If no choices were provided on the command-line, then we check for
+    #    choice(s) specified in the pytest module file (aka one of our
+    #    'integtest' files). For this, we check for a variable named
+    #    'process_manager_choices'.
+    # If neither of those two ways of specifying the PM type were used in
+    #    the current testing, then we default to the SSH standalone PM type.
+    # In all cases, we want to create a dictionary that has a descriptive name
+    #    and the PM type for each entry
+    cmdline_pmtype = metafunc.config.getoption("--process-manager-type")
+    if cmdline_pmtype:  # a PM type was specified on the command line
+        # translate the one or more PM types into a dictionary
+        pmtype_dict = {}
+        type_list = cmdline_pmtype.split('|')
+        for pm_type in type_list:
+            type_name = pm_type.upper()+"_PM"
+            type_name = type_name.replace("-", "_")
+            addl_dict_entry = {type_name : pm_type}
+            pmtype_dict.update(addl_dict_entry)
+        # assign this new dictionary to the metafunc.module parameter used later
+        metafunc.module.process_manager_choices = pmtype_dict
+    elif not hasattr(metafunc.module, "process_manager_choices"):
+        # create an entry for the default choice of ssh-standalone
+        metafunc.module.process_manager_choices = { "StandAloneSSH_PM" : "ssh-standalone" }
+
 
     parametrize_fixture_with_items(metafunc, "create_config_files", "confgen_arguments")
     parametrize_fixture_with_items(metafunc, "process_manager_type", "process_manager_choices")
@@ -84,10 +109,7 @@ def pytest_generate_tests(metafunc):
 # 29-Dec-2025, KAB: added fixture to handle different process manager choices
 @pytest.fixture(scope="module")
 def process_manager_type(request, tmp_path_factory):
-    result = ProcessManagerChoice (
-        pm_type = request.param["pm_type"]
-    )
-    yield result
+    yield request.param
 
 @pytest.fixture(scope="module")
 def check_system_resources(request):
@@ -515,7 +537,7 @@ def run_nanorc(request, create_config_files, process_manager_type, tmp_path_fact
     result.completed_process = subprocess.run(
         [nanorc]
         + nanorc_option_strings
-        + [str(process_manager_type.pm_type)]  # 29-Dec-2025, KAB: support for ProcMgr choices
+        + [str(process_manager_type)]
         + [str(create_config_files.config_file)]
         + [str(create_config_files.config.session)]
         + [str(create_config_files.config.session_name if create_config_files.config.session_name else create_config_files.config.session)]


### PR DESCRIPTION
# Description

Please Note:  This PR needs to be tested and merged in conjunction with DUNE-DAQ/daqsystemtest#302.

In response to a request from our run control colleagues, we have provided the ability to specify the process manager type that is used by integration tests from the command line.

With the changes included in this PR and the corresponding one in `daqsystemtest`, users can do this in the following ways:

```
pytest -s --process-manager-type ssh-standalone minimal_system_quick_test.py

dunedaq_integtest_bundle.sh -k min --pytest-options "--process-manager-type ssh-standalone"
```

Here are sample steps for testing these changes:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260305_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/pmtype_from_commandline
cd ..

cd pythoncode
git clone https://github.com/DUNE-DAQ/integrationtest.git -b kbiery/pmtype_from_commandline
cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -k min --pytest-options "--process-manager-type ssh-standalone"
```

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
