### PR TITLE
Added capture of the run control console output so that it can be used for validations

### DIFF
--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -551,28 +551,45 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
     print(
         "++++++++++ DRUNC Run BEGIN ++++++++++", flush=True
     )  # Apparently need to flush before subprocess.run
-    print("", flush=True)
-    print("*** Temporarily capturing the DRUNC output (will print it out at the end) ***", flush=True)
     result = RunResult()
     time_before = time.time()
-    result.completed_process = subprocess.run(
+    rc_process = subprocess.Popen(
         [dunerc]
         + dunerc_option_strings
-        + [process_manager_type]  # 29-Dec-2025, KAB: support for ProcMgr choices
+        + [process_manager_type]
         + [str(create_config_files.config_file)]
         + [str(create_config_files.config.session)]
         + [str(create_config_files.config.session_name if create_config_files.config.session_name else create_config_files.config.session)]
         + command_list,
-        cwd=run_dir, capture_output=True, text=True
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        cwd=run_dir
+    )
+
+    full_output = ""
+    for line in rc_process.stdout:
+        #if "Booting session" in line or "Running transition" in line \
+        #   or ("wait" in line and "running" in line) or "exit code" in line:
+        print(line, end='', flush=True)
+        full_output += line
+
+    rc_process.communicate()
+    proc_returncode = rc_process.returncode
+
+    result.completed_process = subprocess.CompletedProcess(
+        [dunerc]
+        + dunerc_option_strings
+        + [process_manager_type]
+        + [str(create_config_files.config_file)]
+        + [str(create_config_files.config.session)]
+        + [str(create_config_files.config.session_name if create_config_files.config.session_name else create_config_files.config.session)]
+        + command_list,
+        returncode=proc_returncode,
+        stdout=full_output
     )
     time_after = time.time()
-
-    print("", flush=True)
-    print("*** DRUNC stdout:", flush=True)
-    print(result.completed_process.stdout)
-    print("", flush=True)
-    print("*** DRUNC stderr:", flush=True)
-    print(result.completed_process.stderr)
 
     if connsvc_obj is not None:
         time.sleep(1)

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -553,6 +553,8 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
     )  # Apparently need to flush before subprocess.run
     result = RunResult()
     time_before = time.time()
+    # 25-Mar-2026, KAB: use subprocess.Popen to manage the run control session so that we can
+    # capture the console output and pass it back to the user for inspection and validation.
     rc_process = subprocess.Popen(
         [dunerc]
         + dunerc_option_strings
@@ -568,16 +570,19 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
         cwd=run_dir
     )
 
+    # print out each line of captured output, as well as add it to the string that we
+    # pass back to the user
     full_output = ""
     for line in rc_process.stdout:
-        #if "Booting session" in line or "Running transition" in line \
-        #   or ("wait" in line and "running" in line) or "exit code" in line:
         print(line, end='', flush=True)
         full_output += line
 
     rc_process.communicate()
     proc_returncode = rc_process.returncode
 
+    # construct a CompletedProcess instance to be passed back to the user. In this way,
+    # user code does not need to change in response to the change in this code from
+    # using subprocess.run() to subprocess.Popen().
     result.completed_process = subprocess.CompletedProcess(
         [dunerc]
         + dunerc_option_strings

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -551,6 +551,8 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
     print(
         "++++++++++ DRUNC Run BEGIN ++++++++++", flush=True
     )  # Apparently need to flush before subprocess.run
+    print("", flush=True)
+    print("*** Temporarily capturing the DRUNC output (will print it out at the end) ***", flush=True)
     result = RunResult()
     time_before = time.time()
     result.completed_process = subprocess.run(
@@ -561,9 +563,16 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
         + [str(create_config_files.config.session)]
         + [str(create_config_files.config.session_name if create_config_files.config.session_name else create_config_files.config.session)]
         + command_list,
-        cwd=run_dir,
+        cwd=run_dir, capture_output=True, text=True
     )
     time_after = time.time()
+
+    print("", flush=True)
+    print("*** DRUNC stdout:", flush=True)
+    print(result.completed_process.stdout)
+    print("", flush=True)
+    print("*** DRUNC stderr:", flush=True)
+    print(result.completed_process.stderr)
 
     if connsvc_obj is not None:
         time.sleep(1)


### PR DESCRIPTION
# Description

Recently, Emir asked if the console output from `drunc` could be captured and made available to our integtest validation checks.  This PR contains the first version of code to do that.  The console output continues to be printed out in real time, and it is now available in the `completed_process.stdout` attribute of the result of the `run_dunerc` fixture.  This is available in our tests as `run_dunerc.completed_process.stdout`.

We have tested this by installing this branch of `integrationtest` in a local software area and verifying that all of the usual regression tests work as before.

The target release for these changes is `fddaq-v5.7.0`.

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
