### PR TITLE
Improved the naming of configuration session name and DAQ session name variables used in integtests

### DIFF
--- a/src/integrationtest/data_classes.py
+++ b/src/integrationtest/data_classes.py
@@ -46,11 +46,12 @@ class list_element_addition(config_substitution):
     additional_object_class: str = ""
     additional_object_id: str = ""
 
+
 @dataclass
 class drunc_config:
     op_env: str = "integtest"
-    session: str = "integtest"
-    session_name: str = None
+    config_session_name: str = "integtest"
+    daq_session_name: str = None
     dro_map_config: DROMap_config = field(default_factory=lambda: DROMap_config(1))
     frame_file: str = "asset://?checksum=370df564205290d27cab47e44ae4ca47"
     tpg_enabled: bool = False

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -399,7 +399,7 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
     each set of arguments in the list
 
     """
-    command_list = request.param
+    run_control_commands = request.param
 
     disable_connectivity_service = request.config.getoption(
         "--disable-connectivity-service"
@@ -560,14 +560,11 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
     time_before = time.time()
     # 25-Mar-2026, KAB: use subprocess.Popen to manage the run control session so that we can
     # capture the console output and pass it back to the user for inspection and validation.
+    popen_command_list = [dunerc] + dunerc_option_strings + [process_manager_type] \
+        + [str(create_config_files.config_file)] + [str(create_config_files.config.config_session_name)] \
+        + [str(create_config_files.config.daq_session_name)] + run_control_commands
     rc_process = subprocess.Popen(
-        [dunerc]
-        + dunerc_option_strings
-        + [process_manager_type]
-        + [str(create_config_files.config_file)]
-        + [str(create_config_files.config.config_session_name)]
-        + [str(create_config_files.config.daq_session_name)]
-        + command_list,
+        popen_command_list,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -589,13 +586,7 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
     # user code does not need to change in response to the change in this code from
     # using subprocess.run() to subprocess.Popen().
     result.completed_process = subprocess.CompletedProcess(
-        [dunerc]
-        + dunerc_option_strings
-        + [process_manager_type]
-        + [str(create_config_files.config_file)]
-        + [str(create_config_files.config.session)]
-        + [str(create_config_files.config.session_name if create_config_files.config.session_name else create_config_files.config.session)]
-        + command_list,
+        popen_command_list,
         returncode=proc_returncode,
         stdout=full_output
     )
@@ -621,8 +612,8 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
     result.daq_session_name = create_config_files.config.daq_session_name
     # 27-Feb-2026, KAB: the nanorc_commands return value can be removed once
     # all integtests have been changed to use "dunerc".
-    result.nanorc_commands = command_list
-    result.dunerc_commands = command_list
+    result.nanorc_commands = run_control_commands
+    result.dunerc_commands = run_control_commands
     result.run_dir = run_dir
     result.config_dir = create_config_files.config_dir
     result.data_files = []

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -144,6 +144,11 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
         "--skip-resource-checks"
     )
 
+    # 06-Mar-2026, KAB: if the DAQ session name has not explicitly been set by the
+    # user, set it here so that we can make use of it from this point onward.
+    if not drunc_config.daq_session_name:
+        drunc_config.daq_session_name = drunc_config.config_session_name
+
     config_dir = tmp_path_factory.mktemp("config")
     boot_file = config_dir / "boot.json"
     configfile = config_dir / "config.json"
@@ -229,7 +234,7 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
             include=local_object_databases
             + [str(readout_db), str(trigger_db), str(dataflow_db)]
             + ([str(hsi_db)] if drunc_config.fake_hsi_enabled else []),
-            session_name=drunc_config.session,
+            session_name=drunc_config.config_session_name,
             op_env=drunc_config.op_env,
             connectivity_service_is_infrastructure_app=drunc_config.drunc_connsvc,
             disable_connectivity_service=disable_connectivity_service,
@@ -239,17 +244,17 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
     if drunc_config.connsvc_port is not None:
         drunc_config.connsvc_port = set_connectivity_service_port(
             oksfile=str(config_db),
-            session_name=drunc_config.session,
+            session_name=drunc_config.config_session_name,
             connsvc_port=drunc_config.connsvc_port, # Default is 0, which causes random port to be selected
         )
     # 05-Nov-2025, KAB, MiR: added the setting of a random RC port
-    set_rc_controller_port(oksfile=str(config_db), session_name=drunc_config.session, rc_port=0)
+    set_rc_controller_port(oksfile=str(config_db), session_name=drunc_config.config_session_name, rc_port=0)
 
     # 03-Jul-2025, KAB: added the setting of the TRACE_FILE env var in the OKS Session,
     # if it is set in the user's environment, and if it is not already set in the configuration.
     try:
         trace_file_env_var = os.environ["TRACE_FILE"]
-        set_session_env_var(str(config_db), drunc_config.session, "TRACE_FILE", trace_file_env_var, overwrite=False)
+        set_session_env_var(str(config_db), drunc_config.config_session_name, "TRACE_FILE", trace_file_env_var, overwrite=False)
     except KeyError:
         pass
 
@@ -291,7 +296,7 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
     db.commit()
 
     # For preconfigured tests, disable starting the ConnSvc if the ConnectionService is an ifapp or unused
-    sessionobj = db.get_dal(class_name="Session", uid=drunc_config.session)
+    sessionobj = db.get_dal(class_name="Session", uid=drunc_config.config_session_name)
     if sessionobj.connectivity_service is None:
         drunc_config.drunc_connsvc = True
     for if_app in sessionobj.infrastructure_applications:
@@ -408,7 +413,7 @@ def run_nanorc(request, create_config_files, process_manager_type, tmp_path_fact
 
         connsvc_log = open(
             run_dir
-            / f"log_{getpass.getuser()}_{create_config_files.config.session}_connectivity-service.txt",
+            / f"log_{getpass.getuser()}_{create_config_files.config.daq_session_name}_connectivity-service.txt",
             "w",
         )
         connsvc_obj = subprocess.Popen(
@@ -517,8 +522,8 @@ def run_nanorc(request, create_config_files, process_manager_type, tmp_path_fact
         + nanorc_option_strings
         + [str(process_manager_type.pm_type)]  # 29-Dec-2025, KAB: support for ProcMgr choices
         + [str(create_config_files.config_file)]
-        + [str(create_config_files.config.session)]
-        + [str(create_config_files.config.session_name if create_config_files.config.session_name else create_config_files.config.session)]
+        + [str(create_config_files.config.config_session_name)]
+        + [str(create_config_files.config.daq_session_name)]
         + command_list,
         cwd=run_dir,
     )
@@ -540,8 +545,8 @@ def run_nanorc(request, create_config_files, process_manager_type, tmp_path_fact
         subprocess.run(["killall", "gunicorn", "drunc-controller"])
 
     result.confgen_config = create_config_files.config
-    result.session = create_config_files.config.session
-    result.session_name = create_config_files.config.session_name
+    result.config_session_name = create_config_files.config.config_session_name
+    result.daq_session_name = create_config_files.config.daq_session_name
     result.nanorc_commands = command_list
     result.run_dir = run_dir
     result.config_dir = create_config_files.config_dir
@@ -561,7 +566,7 @@ def run_nanorc(request, create_config_files, process_manager_type, tmp_path_fact
             trmon_dir.glob(f"{create_config_files.config.op_env}_trmon_*.hdf5")
         )
     result.log_files = list(run_dir.glob("log_*.txt")) + list(run_dir.glob("log_*.log"))
-    result.opmon_files = list(run_dir.glob(f"info*{result.session_name if result.session_name else result.session}*.json"))
+    result.opmon_files = list(run_dir.glob(f"info*{result.daq_session_name}*.json"))
     # 10-Dec-2025, KAB: added the DAQ session overall time so that we can use this
     # information in fine-tuning the allowed ranges in time-based checking of test results.
     result.daq_session_overall_time = time_after - time_before


### PR DESCRIPTION
# Description

These changes are intended to be included in `fddaq-v5.7.0`...

To me, it seems really beneficial to improve the naming of variables and parameters in our code so that we can differentiate between Configuration Session names (aka OKS Session names) and DAQ Session names. 

One of the places in our existing code where I found the current names confusing is in the `integrationtest` `drunc_config` data structure.

To help make things more clear, I propose that we modify 

- `drunc_config.session` to `drunc_config.config_session_name`
- `drunc_config.session_name` to `drunc_config.daq_session_name`

This PR has these changes.  If there are suggestions for better new names, we can certainly talk about that (`configuration_session_name`?).

These changes are coupled with ones in the following repositories:

- DUNE-DAQ/daqsystemtest#313
- DUNE-DAQ/dfmodules#487
- DUNE-DAQ/listrev#121
- DUNE-DAQ/snbmodules#31
- DUNE-DAQ/trigger#431

Here are suggested instructions for testing the full set of changes:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260415_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/integtest_session_name_changes
git clone https://github.com/DUNE-DAQ/dfmodules.git -b kbiery/integtest_session_name_changes
git clone https://github.com/DUNE-DAQ/listrev.git -b kbiery/integtest_session_name_changes
git clone https://github.com/DUNE-DAQ/snbmodules.git -b kbiery/integtest_session_name_changes
git clone https://github.com/DUNE-DAQ/trigger.git -b kbiery/integtest_session_name_changes
cd ..

cd pythoncode
git clone https://github.com/DUNE-DAQ/integrationtest.git -b kbiery/integtest_session_name_changes
cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -k min
```

I have run tests on `daq.fnal.gov` and `np04-srv-029` with all of the modified integtests (`dunedaq_integtest_bundle.sh -r local`), and the results look good.

And, I should say that I have additional improvements planned to help make it easier for users to know how to specify configuration (`confgen_parameters`) information in our integtests.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
