### PR TITLE
Updated the filtering of drunc messages when the verbosity level of integtests is reduced…

### DIFF
--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -678,7 +678,7 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
 
         # check for errors and warnings for all verbosity levels
         if should_be_printed == False:
-            if ("error" in line.lower() and not " In error " in line) or "warning" in line.lower():
+            if ("error" in line.lower() and (not "In error" in line and not "Endpoint" in line)) or "warning" in line.lower():
                 should_be_printed = True
 
         # check for basic transition messages, if that level of verbosity is requested


### PR DESCRIPTION
… to handle "In error" messages that now have special formatting.

# Description

Simply reacting to a change in formatting of `drunc` console messages...

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
