### PR TITLE
Reorganized the integration test parameters that developers use to specify a DUNE DAQ configuration

### DIFF
--- a/src/integrationtest/data_classes.py
+++ b/src/integrationtest/data_classes.py
@@ -65,9 +65,19 @@ class drunc_config:
     object_databases: list[str] = field(default_factory=list)
     config_substitutions: list[config_substitution] = field(default_factory=list)
     attempt_cleanup: bool = False
-    drunc_connsvc: bool = False
+    # parameter(s) related to the startup of the Connectivity Service
+    connsvc_debug_level: int = None
+
+@dataclass
+class integtest_params_for_generated_dunedaq_config(drunc_config):
+    # parameter(s) related to the startup of the Connectivity Service
+    connsvc_control: str = "integrationtest"  # vs "drunc" or "none"/None
     connsvc_port: int = 0
-    connsvc_debug_level: int = 0
+
+@dataclass
+class integtest_params_for_predefined_dunedaq_config(drunc_config):
+    # parameter(s) related to the startup of the Connectivity Service
+    connsvc_port: int = None
 
 
 @dataclass

--- a/src/integrationtest/data_classes.py
+++ b/src/integrationtest/data_classes.py
@@ -53,7 +53,7 @@ class ConnSvcControl(Enum):
     NONE = "none"
 
 @dataclass
-class integtest_param_class:
+class integtest_param_base_class:
     # daq_session_name can be specified; it is automatically populated if not specified
     daq_session_name: str = None
 
@@ -68,7 +68,7 @@ class integtest_param_class:
     connsvc_debug_level: int = None
 
 @dataclass
-class integtest_params_for_generated_dunedaq_config(integtest_param_class):
+class integtest_params_for_generated_dunedaq_config(integtest_param_base_class):
     # *** Parameters that are needed for both generated and predefined configs,
     # *** and benefit from different default values
     # - for generated configs, these two params do not need to have specific values
@@ -92,7 +92,7 @@ class integtest_params_for_generated_dunedaq_config(integtest_param_class):
     connsvc_control: ConnSvcControl = ConnSvcControl.INTEGRATIONTEST
 
 @dataclass
-class integtest_params_for_predefined_dunedaq_config(integtest_param_class):
+class integtest_params_for_predefined_dunedaq_config(integtest_param_base_class):
     # *** Parameters that are needed for both generated and predefined configs,
     # *** and benefit from different default values
     # - for a predefined config, the following two parameters must contain values that
@@ -107,7 +107,7 @@ class integtest_params_for_predefined_dunedaq_config(integtest_param_class):
 
 @dataclass
 class CreateConfigResult:
-    config: integtest_param_class
+    config: integtest_param_base_class
     config_dir: str
     config_file: str
     log_file: str

--- a/src/integrationtest/data_classes.py
+++ b/src/integrationtest/data_classes.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-
+from enum import Enum
 
 @dataclass
 class DROMap_config:
@@ -47,42 +47,67 @@ class list_element_addition(config_substitution):
     additional_object_id: str = ""
 
 
+class ConnSvcControl(Enum):
+    INTEGRATIONTEST = "integrationtest"
+    RUNCONTROL = "runcontrol"
+    NONE = "none"
+
 @dataclass
-class drunc_config:
+class integtest_param_class:
+    # daq_session_name can be specified; it is automatically populated if not specified
+    daq_session_name: str = None
+
+    # config substitutions can be made to both generated and predefined dunedaq configs
+    config_substitutions: list[config_substitution] = field(default_factory=list)
+
+    # the cleanup of leftover RunControl or ConnSvc processes is available to all types of integtests
+    attempt_cleanup: bool = False
+
+    # parameter(s) related to the startup of the Connectivity Service
+    connsvc_port: int = 0
+    connsvc_debug_level: int = None
+
+@dataclass
+class integtest_params_for_generated_dunedaq_config(integtest_param_class):
+    # *** Parameters that are needed for both generated and predefined configs,
+    # *** and benefit from different default values
+    # - for generated configs, these two params do not need to have specific values
     op_env: str = "integtest"
     config_session_name: str = "integtest"
-    daq_session_name: str = None
+
+    # *** Parameters that are only needed for generated dunedaq configurations
+    # - databases that are needed to support config generation
+    object_databases: list[str] = field(default_factory=list)
+    # - parameters that control what the generators produce
     dro_map_config: DROMap_config = field(default_factory=lambda: DROMap_config(1))
-    frame_file: str = "asset://?checksum=370df564205290d27cab47e44ae4ca47"
+    frame_file: str = "asset://?checksum=370df564205290d27cab47e44ae4ca47"  # wib_link_67.bin
     tpg_enabled: bool = False
     trmon_app_enabled: bool = False
     fake_hsi_enabled: bool = False
     use_fakedataprod: bool = False
     fake_data_fragment_type: str = ""
-    config_db: str = ""
     n_df_apps: int = 1
     n_data_writers: int = 1
-    object_databases: list[str] = field(default_factory=list)
-    config_substitutions: list[config_substitution] = field(default_factory=list)
-    attempt_cleanup: bool = False
-    # parameter(s) related to the startup of the Connectivity Service
-    connsvc_debug_level: int = None
+    # - control over how the Connectivity Service is started
+    connsvc_control: ConnSvcControl = ConnSvcControl.INTEGRATIONTEST
 
 @dataclass
-class integtest_params_for_generated_dunedaq_config(drunc_config):
-    # parameter(s) related to the startup of the Connectivity Service
-    connsvc_control: str = "integrationtest"  # vs "drunc" or "none"/None
-    connsvc_port: int = 0
+class integtest_params_for_predefined_dunedaq_config(integtest_param_class):
+    # *** Parameters that are needed for both generated and predefined configs,
+    # *** and benefit from different default values
+    # - for a predefined config, the following two parameters must contain values that
+    #   match what is in that config; they are likely reassigned in integtest files
+    op_env: str = "test"
+    config_session_name: str = "local-1x1-config"
 
-@dataclass
-class integtest_params_for_predefined_dunedaq_config(drunc_config):
-    # parameter(s) related to the startup of the Connectivity Service
-    connsvc_port: int = None
+    # *** Parameters that are unique to predefined dunedaq configurations
+    # - the predefined configuration that should be used
+    predefined_config_db: str = ""
 
 
 @dataclass
 class CreateConfigResult:
-    config: drunc_config
+    config: integtest_param_class
     config_dir: str
     config_file: str
     log_file: str

--- a/src/integrationtest/integrationtest_commandline.py
+++ b/src/integrationtest/integrationtest_commandline.py
@@ -22,7 +22,7 @@ def pytest_addoption(parser):
         required=False
     )
     parser.addoption(
-        "--disable-connectivity-service",
+        "--no-integtest-connsvc",
         action="store_true",
         default=False,
         help="Whether to disable the Connectivity Service for this test",

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -461,7 +461,7 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
     integtest_verbosity_level = int(request.config.getoption("--integtest-verbosity"))
 
     if no_integtest_connsvc and \
-       isinstance(drunc_config, integtest_params_for_generated_dunedaq_config):
+       isinstance(create_config_files.config, integtest_params_for_generated_dunedaq_config):
         create_config_files.config.connsvc_control = ConnSvcControl.NONE
 
     run_dir = tmp_path_factory.mktemp("run")
@@ -513,9 +513,10 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
         # if the expected env var is not set, we simply don't create the bundle info file
         pass
 
+    # start the Connectivity Service, if requested (only supported for generated dune-daq configs, for now)
     connsvc_obj = None
     if (
-        hasattr(create_config_files.config, "connsvc_control")
+        isinstance(create_config_files.config, integtest_params_for_generated_dunedaq_config)
         and create_config_files.config.connsvc_control == ConnSvcControl.INTEGRATIONTEST
     ):
         # start connsvc
@@ -541,6 +542,10 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
             stderr=connsvc_log,
             env=connsvc_env,
         )
+
+    elif create_config_files.config.connsvc_debug_level is not None:
+        set_session_env_var(str(create_config_files.config_file), create_config_files.config.config_session_name,
+                            "CONNECTION_FLASK_DEBUG", create_config_files.config.connsvc_debug_level, overwrite=True)
 
     dunerc = request.config.getoption("--dunerc-path")
     if dunerc is None:

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -205,11 +205,11 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
     """
     dummy_resource_check = check_system_resources
     drunc_config = request.param
-    if isinstance(drunc_config, integtest_params_for_generated_dunedaq_config):
-        print("*** drunc_config is of type integtest_params_for_generated_dunedaq_config")
-    if isinstance(drunc_config, integtest_params_for_predefined_dunedaq_config):
-        print("*** drunc_config is of type integtest_params_for_predefined_dunedaq_config")
 
+    #if isinstance(drunc_config, integtest_params_for_generated_dunedaq_config):
+    #    print("*** drunc_config is of type integtest_params_for_generated_dunedaq_config")
+    #if isinstance(drunc_config, integtest_params_for_predefined_dunedaq_config):
+    #    print("*** drunc_config is of type integtest_params_for_predefined_dunedaq_config")
     if not isinstance(drunc_config, integtest_params_for_generated_dunedaq_config) \
        and not isinstance(drunc_config, integtest_params_for_predefined_dunedaq_config):
         fail_msg = f"The integtest configuration object has an invalid type: {type(drunc_config)}"

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -20,6 +20,8 @@ from integrationtest.data_classes import (
     relationship_substitution,
     list_element_substitution,
     list_element_addition,
+    integtest_params_for_generated_dunedaq_config,
+    integtest_params_for_predefined_dunedaq_config,
 )
 from daqconf.generate_hwmap import generate_hwmap
 from daqconf.generate import (
@@ -202,10 +204,22 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
     """
     dummy_resource_check = check_system_resources
     drunc_config = request.param
+    if isinstance(drunc_config, integtest_params_for_generated_dunedaq_config):
+        print("*** drunc_config is of type integtest_params_for_generated_dunedaq_config")
+    if isinstance(drunc_config, integtest_params_for_predefined_dunedaq_config):
+        print("*** drunc_config is of type integtest_params_for_predefined_dunedaq_config")
+
+    if not isinstance(drunc_config, integtest_params_for_generated_dunedaq_config) \
+       and not isinstance(drunc_config, integtest_params_for_predefined_dunedaq_config):
+        fail_msg = f"The integtest configuration object has an invalid type: {type(drunc_config)}"
+        pytest.fail(fail_msg, pytrace=False)
 
     disable_connectivity_service = request.config.getoption(
         "--disable-connectivity-service"
     )
+    if disable_connectivity_service and \
+       isinstance(drunc_config, integtest_params_for_generated_dunedaq_config):
+        drunc_config.connsvc_control = None
     skip_resource_checks = request.config.getoption(
         "--skip-resource-checks"
     )
@@ -309,6 +323,9 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
             trmon_app=drunc_config.trmon_app_enabled,
         )
 
+        drunc_starts_connsvc = hasattr(drunc_config, "connsvc_control") \
+            and drunc_config.connsvc_control is not None \
+            and "drunc" in drunc_config.connsvc_control
         generate_session(
             oksfile=str(temp_config_db),
             include=local_object_databases
@@ -316,7 +333,7 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
             + ([str(hsi_db)] if drunc_config.fake_hsi_enabled else []),
             session_name=drunc_config.config_session_name,
             op_env=drunc_config.op_env,
-            connectivity_service_is_infrastructure_app=drunc_config.drunc_connsvc,
+            connectivity_service_is_infrastructure_app=drunc_starts_connsvc,
             disable_connectivity_service=disable_connectivity_service,
         )
 
@@ -375,15 +392,8 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
 
     db.commit()
 
-    # For preconfigured tests, disable starting the ConnSvc if the ConnectionService is an ifapp or unused
-    sessionobj = db.get_dal(class_name="Session", uid=drunc_config.config_session_name)
-    if sessionobj.connectivity_service is None:
-        drunc_config.drunc_connsvc = True
-    for if_app in sessionobj.infrastructure_applications:
-        if if_app.className() == "ConnectionService":
-            drunc_config.drunc_connsvc = True
-
     # 30-Dec-2024, KAB: build up the list of directories used for writing raw and TPStream data
+    sessionobj = db.get_dal(class_name="Session", uid=drunc_config.config_session_name)
     rawdata_dirs = []
     tpstream_dirs = []
     trmon_dirs = []
@@ -454,6 +464,9 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
     disable_connectivity_service = request.config.getoption(
         "--disable-connectivity-service"
     )
+    if disable_connectivity_service and \
+       isinstance(drunc_config, integtest_params_for_generated_dunedaq_config):
+        create_config_files.config.connsvc_control = None
     integtest_verbosity_level = int(request.config.getoption("--integtest-verbosity"))
 
     run_dir = tmp_path_factory.mktemp("run")
@@ -507,9 +520,9 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
 
     connsvc_obj = None
     if (
-        not disable_connectivity_service
-        and not create_config_files.config.drunc_connsvc
-        and create_config_files.config.connsvc_port is not None
+        hasattr(create_config_files.config, "connsvc_control")
+        and create_config_files.config.connsvc_control is not None
+        and "integ" in create_config_files.config.connsvc_control
     ):
         # start connsvc
         if integtest_verbosity_level >= IntegtestVerbosityLevels.full_output:
@@ -518,9 +531,10 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
             )
 
         connsvc_env = os.environ.copy()
-        connsvc_env["CONNECTION_FLASK_DEBUG"] = str(
-            create_config_files.config.connsvc_debug_level
-        )
+        if create_config_files.config.connsvc_debug_level is not None:
+            connsvc_env["CONNECTION_FLASK_DEBUG"] = str(
+                create_config_files.config.connsvc_debug_level
+            )
 
         connsvc_log = open(
             run_dir

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -20,6 +20,7 @@ from integrationtest.data_classes import (
     relationship_substitution,
     list_element_substitution,
     list_element_addition,
+    ConnSvcControl,
     integtest_params_for_generated_dunedaq_config,
     integtest_params_for_predefined_dunedaq_config,
 )
@@ -214,15 +215,12 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
         fail_msg = f"The integtest configuration object has an invalid type: {type(drunc_config)}"
         pytest.fail(fail_msg, pytrace=False)
 
-    disable_connectivity_service = request.config.getoption(
-        "--disable-connectivity-service"
-    )
-    if disable_connectivity_service and \
+    no_integtest_connsvc = request.config.getoption("--no-integtest-connsvc")
+    skip_resource_checks = request.config.getoption("--skip-resource-checks")
+
+    if no_integtest_connsvc and \
        isinstance(drunc_config, integtest_params_for_generated_dunedaq_config):
-        drunc_config.connsvc_control = None
-    skip_resource_checks = request.config.getoption(
-        "--skip-resource-checks"
-    )
+        drunc_config.connsvc_control = ConnSvcControl.NONE
 
     # 06-Mar-2026, KAB: if the DAQ session name has not explicitly been set by the
     # user, set it here so that we can make use of it from this point onward.
@@ -243,27 +241,27 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
         sys.stdout = catcher = StringIO()
 
     config_dir = tmp_path_factory.mktemp("config")
-    boot_file = config_dir / "boot.json"
-    configfile = config_dir / "config.json"
-    dro_map_file = config_dir / "ReadoutMap.data.xml"
-    readout_db = config_dir / "readout-segment.data.xml"
-    dataflow_db = config_dir / "df-segment.data.xml"
-    trigger_db = config_dir / "trg-segment.data.xml"
-    hsi_db = config_dir / "hsi-segment.data.xml"
     config_db = config_dir / "integtest-session-resolved.data.xml"
     temp_config_db = config_dir / "integtest-session.data.xml"
     logfile = tmp_path_factory.getbasetemp() / f"stdouterr{request.param_index}.txt"
 
-    integtest_conf = drunc_config.config_db
-
-    object_databases = getattr(request.module, "object_databases", [])
-    local_object_databases = copy_configuration(config_dir, object_databases)
-
-    #print()  # Blank line
-    if file_exists(integtest_conf):
-        print(f"Integtest preconfigured config file: {integtest_conf}")
-        consolidate_files(str(temp_config_db), integtest_conf, *local_object_databases)
+    if isinstance(drunc_config, integtest_params_for_predefined_dunedaq_config):
+        integtest_conf = drunc_config.predefined_config_db
+        if file_exists(integtest_conf):
+            print(f"Integtest preconfigured config file: {integtest_conf}")
+            consolidate_files(str(temp_config_db), integtest_conf)
+        else:
+            fail_msg = f"The file containing the predefined dunedaq configuration \"{integtest_conf}\" could not be found."
+            pytest.fail(fail_msg, pytrace=False)
     else:
+        dro_map_file = config_dir / "ReadoutMap.data.xml"
+        readout_db = config_dir / "readout-segment.data.xml"
+        dataflow_db = config_dir / "df-segment.data.xml"
+        trigger_db = config_dir / "trg-segment.data.xml"
+        hsi_db = config_dir / "hsi-segment.data.xml"
+
+        local_object_databases = copy_configuration(config_dir, drunc_config.object_databases)
+
         if not drunc_config.use_fakedataprod:
             if not file_exists(dro_map_file):
                 dro_map_config = drunc_config.dro_map_config
@@ -323,9 +321,7 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
             trmon_app=drunc_config.trmon_app_enabled,
         )
 
-        drunc_starts_connsvc = hasattr(drunc_config, "connsvc_control") \
-            and drunc_config.connsvc_control is not None \
-            and "drunc" in drunc_config.connsvc_control
+        runcontrol_starts_connsvc = drunc_config.connsvc_control == ConnSvcControl.RUNCONTROL
         generate_session(
             oksfile=str(temp_config_db),
             include=local_object_databases
@@ -333,8 +329,8 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
             + ([str(hsi_db)] if drunc_config.fake_hsi_enabled else []),
             session_name=drunc_config.config_session_name,
             op_env=drunc_config.op_env,
-            connectivity_service_is_infrastructure_app=drunc_starts_connsvc,
-            disable_connectivity_service=disable_connectivity_service,
+            connectivity_service_is_infrastructure_app=runcontrol_starts_connsvc,
+            disable_connectivity_service=no_integtest_connsvc,
         )
 
     consolidate_db(str(temp_config_db), str(config_db))
@@ -461,13 +457,12 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
     """
     run_control_commands = request.param
 
-    disable_connectivity_service = request.config.getoption(
-        "--disable-connectivity-service"
-    )
-    if disable_connectivity_service and \
-       isinstance(drunc_config, integtest_params_for_generated_dunedaq_config):
-        create_config_files.config.connsvc_control = None
+    no_integtest_connsvc = request.config.getoption("--no-integtest-connsvc")
     integtest_verbosity_level = int(request.config.getoption("--integtest-verbosity"))
+
+    if no_integtest_connsvc and \
+       isinstance(drunc_config, integtest_params_for_generated_dunedaq_config):
+        create_config_files.config.connsvc_control = ConnSvcControl.NONE
 
     run_dir = tmp_path_factory.mktemp("run")
 
@@ -521,8 +516,7 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
     connsvc_obj = None
     if (
         hasattr(create_config_files.config, "connsvc_control")
-        and create_config_files.config.connsvc_control is not None
-        and "integ" in create_config_files.config.connsvc_control
+        and create_config_files.config.connsvc_control == ConnSvcControl.INTEGRATIONTEST
     ):
         # start connsvc
         if integtest_verbosity_level >= IntegtestVerbosityLevels.full_output:

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -204,28 +204,28 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
 
     """
     dummy_resource_check = check_system_resources
-    drunc_config = request.param
+    integtest_params = request.param
 
-    #if isinstance(drunc_config, integtest_params_for_generated_dunedaq_config):
-    #    print("*** drunc_config is of type integtest_params_for_generated_dunedaq_config")
-    #if isinstance(drunc_config, integtest_params_for_predefined_dunedaq_config):
-    #    print("*** drunc_config is of type integtest_params_for_predefined_dunedaq_config")
-    if not isinstance(drunc_config, integtest_params_for_generated_dunedaq_config) \
-       and not isinstance(drunc_config, integtest_params_for_predefined_dunedaq_config):
-        fail_msg = f"The integtest configuration object has an invalid type: {type(drunc_config)}"
+    #if isinstance(integtest_params, integtest_params_for_generated_dunedaq_config):
+    #    print("*** integtest_params is of type integtest_params_for_generated_dunedaq_config")
+    #if isinstance(integtest_params, integtest_params_for_predefined_dunedaq_config):
+    #    print("*** integtest_params is of type integtest_params_for_predefined_dunedaq_config")
+    if not isinstance(integtest_params, integtest_params_for_generated_dunedaq_config) \
+       and not isinstance(integtest_params, integtest_params_for_predefined_dunedaq_config):
+        fail_msg = f"The integtest configuration object has an invalid type: {type(integtest_params)}"
         pytest.fail(fail_msg, pytrace=False)
 
     no_integtest_connsvc = request.config.getoption("--no-integtest-connsvc")
     skip_resource_checks = request.config.getoption("--skip-resource-checks")
 
     if no_integtest_connsvc and \
-       isinstance(drunc_config, integtest_params_for_generated_dunedaq_config):
-        drunc_config.connsvc_control = ConnSvcControl.NONE
+       isinstance(integtest_params, integtest_params_for_generated_dunedaq_config):
+        integtest_params.connsvc_control = ConnSvcControl.NONE
 
     # 06-Mar-2026, KAB: if the DAQ session name has not explicitly been set by the
     # user, set it here so that we can make use of it from this point onward.
-    if not drunc_config.daq_session_name:
-        drunc_config.daq_session_name = drunc_config.config_session_name
+    if not integtest_params.daq_session_name:
+        integtest_params.daq_session_name = integtest_params.config_session_name
 
     # 26-Mar-2026, KAB: suppress output messages, if requested
     integtest_verbosity_level = int(request.config.getoption("--integtest-verbosity"))
@@ -245,8 +245,8 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
     temp_config_db = config_dir / "integtest-session.data.xml"
     logfile = tmp_path_factory.getbasetemp() / f"stdouterr{request.param_index}.txt"
 
-    if isinstance(drunc_config, integtest_params_for_predefined_dunedaq_config):
-        integtest_conf = drunc_config.predefined_config_db
+    if isinstance(integtest_params, integtest_params_for_predefined_dunedaq_config):
+        integtest_conf = integtest_params.predefined_config_db
         if file_exists(integtest_conf):
             print(f"Integtest preconfigured config file: {integtest_conf}")
             consolidate_files(str(temp_config_db), integtest_conf)
@@ -260,11 +260,11 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
         trigger_db = config_dir / "trg-segment.data.xml"
         hsi_db = config_dir / "hsi-segment.data.xml"
 
-        local_object_databases = copy_configuration(config_dir, drunc_config.object_databases)
+        local_object_databases = copy_configuration(config_dir, integtest_params.object_databases)
 
-        if not drunc_config.use_fakedataprod:
+        if not integtest_params.use_fakedataprod:
             if not file_exists(dro_map_file):
-                dro_map_config = drunc_config.dro_map_config
+                dro_map_config = integtest_params.dro_map_config
                 if dro_map_config != None:
                     generate_hwmap(
                         str(dro_map_file),
@@ -284,28 +284,28 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
                     oksfile=str(readout_db),
                     include=local_object_databases,
                     generate_segment=True,
-                    emulated_file_name=drunc_config.frame_file,
-                    tpg_enabled=drunc_config.tpg_enabled,
+                    emulated_file_name=integtest_params.frame_file,
+                    tpg_enabled=integtest_params.tpg_enabled,
                 )
         elif not file_exists(readout_db):
             generate_fakedata(
                 oksfile=str(readout_db),
                 include=local_object_databases,
                 generate_segment=True,
-                n_streams=drunc_config.dro_map_config.n_streams,
-                n_apps=drunc_config.dro_map_config.n_apps,
-                det_id=drunc_config.dro_map_config.det_id,
-                fragment_type=drunc_config.fake_data_fragment_type,
+                n_streams=integtest_params.dro_map_config.n_streams,
+                n_apps=integtest_params.dro_map_config.n_apps,
+                det_id=integtest_params.dro_map_config.det_id,
+                fragment_type=integtest_params.fake_data_fragment_type,
             )
 
         generate_trigger(
             oksfile=str(trigger_db),
             include=local_object_databases,
             generate_segment=True,
-            tpg_enabled=drunc_config.tpg_enabled,
-            hsi_enabled=drunc_config.fake_hsi_enabled,
+            tpg_enabled=integtest_params.tpg_enabled,
+            hsi_enabled=integtest_params.fake_hsi_enabled,
         )
-        if drunc_config.fake_hsi_enabled:
+        if integtest_params.fake_hsi_enabled:
             generate_hsi(
                 oksfile=str(hsi_db),
                 include=local_object_databases,
@@ -314,40 +314,40 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
         generate_dataflow(
             oksfile=str(dataflow_db),
             include=local_object_databases,
-            n_dfapps=drunc_config.n_df_apps,
-            tpwriting_enabled=drunc_config.tpg_enabled,
+            n_dfapps=integtest_params.n_df_apps,
+            tpwriting_enabled=integtest_params.tpg_enabled,
             generate_segment=True,
-            n_data_writers=drunc_config.n_data_writers,
-            trmon_app=drunc_config.trmon_app_enabled,
+            n_data_writers=integtest_params.n_data_writers,
+            trmon_app=integtest_params.trmon_app_enabled,
         )
 
-        runcontrol_starts_connsvc = drunc_config.connsvc_control == ConnSvcControl.RUNCONTROL
+        runcontrol_starts_connsvc = integtest_params.connsvc_control == ConnSvcControl.RUNCONTROL
         generate_session(
             oksfile=str(temp_config_db),
             include=local_object_databases
             + [str(readout_db), str(trigger_db), str(dataflow_db)]
-            + ([str(hsi_db)] if drunc_config.fake_hsi_enabled else []),
-            session_name=drunc_config.config_session_name,
-            op_env=drunc_config.op_env,
+            + ([str(hsi_db)] if integtest_params.fake_hsi_enabled else []),
+            session_name=integtest_params.config_session_name,
+            op_env=integtest_params.op_env,
             connectivity_service_is_infrastructure_app=runcontrol_starts_connsvc,
             disable_connectivity_service=no_integtest_connsvc,
         )
 
     consolidate_db(str(temp_config_db), str(config_db))
-    if drunc_config.connsvc_port is not None:
-        drunc_config.connsvc_port = set_connectivity_service_port(
+    if integtest_params.connsvc_port is not None:
+        integtest_params.connsvc_port = set_connectivity_service_port(
             oksfile=str(config_db),
-            session_name=drunc_config.config_session_name,
-            connsvc_port=drunc_config.connsvc_port, # Default is 0, which causes random port to be selected
+            session_name=integtest_params.config_session_name,
+            connsvc_port=integtest_params.connsvc_port, # Default is 0, which causes random port to be selected
         )
     # 05-Nov-2025, KAB, MiR: added the setting of a random RC port
-    set_rc_controller_port(oksfile=str(config_db), session_name=drunc_config.config_session_name, rc_port=0)
+    set_rc_controller_port(oksfile=str(config_db), session_name=integtest_params.config_session_name, rc_port=0)
 
     # 03-Jul-2025, KAB: added the setting of the TRACE_FILE env var in the OKS Session,
     # if it is set in the user's environment, and if it is not already set in the configuration.
     try:
         trace_file_env_var = os.environ["TRACE_FILE"]
-        set_session_env_var(str(config_db), drunc_config.config_session_name, "TRACE_FILE", trace_file_env_var, overwrite=False)
+        set_session_env_var(str(config_db), integtest_params.config_session_name, "TRACE_FILE", trace_file_env_var, overwrite=False)
     except KeyError:
         pass
 
@@ -377,7 +377,7 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
 
         db.update_dal(obj)
 
-    for substitution in drunc_config.config_substitutions:
+    for substitution in integtest_params.config_substitutions:
         if substitution.obj_id != "*":
             obj = db.get_dal(class_name=substitution.obj_class, uid=substitution.obj_id)
             apply_update(obj, substitution)
@@ -389,7 +389,7 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
     db.commit()
 
     # 30-Dec-2024, KAB: build up the list of directories used for writing raw and TPStream data
-    sessionobj = db.get_dal(class_name="Session", uid=drunc_config.config_session_name)
+    sessionobj = db.get_dal(class_name="Session", uid=integtest_params.config_session_name)
     rawdata_dirs = []
     tpstream_dirs = []
     trmon_dirs = []
@@ -423,7 +423,7 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
             pass
 
     result = CreateConfigResult(
-        config=drunc_config,
+        config=integtest_params,
         config_dir=config_dir,
         config_file=config_db,
         log_file=logfile,


### PR DESCRIPTION
... The goal is to help make integtests easier to write and understand.

# Description

These changes are intended for `fddaq-v5.7.0`.

The parameters that developers use to tell the `integrationtest` infrastructure about the characteristics of a requested regression/integration test have historically been a little confusing (at least to me).

The goal of the changes in this PR and the related ones in several other repositories is to make integration tests easier to understand.

A first example of how these changes attempt to do this is the following:

- instead of
    - using a special global variable (`object_databases`) to request that the DUNE-DAQ configuration be generated by the integrationtest infrastructure, and
    - using a certain parameter in a data structure to request/specify that a pre-defined DUNE-DAQ configuration should be used in the integtest
- these changes introduce the use of separate data structures for _generated_ and _pre-defined_ DUNE-DAQ configurations.

The `integtest_params_for_generated_dunedaq_config` Python dataclass has been introduced to request a generated DUNE-DAQ configuration, and it has fields that are appropriate for such generation.

The `integtest_params_for_predefined_dunedaq_config` Python dataclass has been introduced to specify a pre-defined DUNE-DAQ configuration, and it has field(s) that are tailored to pre-defined DUNE-DAQ configurations.

Examples of the use of these dataclasses are available in the updated integtests in various repositories.  Here is a snippet of code from the `minimal_system_quick_test` that requests/specifies a generated DUNE-DAQ configuration:

```
conf_dict = data_classes.integtest_params_for_generated_dunedaq_config()
conf_dict.object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
conf_dict.dro_map_config.n_streams = number_of_data_producers
conf_dict.op_env = "integtest"
conf_dict.config_session_name = "minimal"
conf_dict.tpg_enabled = False
```

Here is a snippet of code from the `example_system_test` that requests/specifies that a pre-defined DUNE-DAQ configuration be used:

```
common_config_obj = data_classes.integtest_params_for_predefined_dunedaq_config()
common_config_obj.op_env = "test"
common_config_obj.predefined_config_db = (
    os.path.dirname(__file__) + "/../config/daqsystemtest/example-configs.data.xml"
)

onebyone_local_conf = copy.deepcopy(common_config_obj)
onebyone_local_conf.config_session_name = "local-1x1-config"
```

The changes in this repository are primarily related to the introduction of these two new dataclasses and the switch to using them.  The changes in the `daqsystemtest`, `dfmodules`, `hsilibs`, `listrev`, `snbmodules`, and `trigger` repositories were needed to keep the various integtests in sync with these changes.

Here are the PRs for the changes in other repositories that are correlated with this one:

- DUNE-DAQ/daqsystemtest#319
- DUNE-DAQ/dfmodules#489
- DUNE-DAQ/hsilibs#85
- DUNE-DAQ/listrev#123
- DUNE-DAQ/snbmodules#33
- DUNE-DAQ/trigger#432

Here are suggested instructions for testing these changes (updated on 15-Jul):

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260715_A9 ${DATE_PREFIX}FDDevIntegtestTriggerChoices_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevIntegtestTriggerChoices_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/crtmodules.git -b kbiery/integtest_trigger_choices
git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/integtest_trigger_choices
git clone https://github.com/DUNE-DAQ/dfmodules.git -b kbiery/integtest_trigger_choices
git clone https://github.com/DUNE-DAQ/hsilibs.git -b develop
git clone https://github.com/DUNE-DAQ/listrev.git -b develop
git clone https://github.com/DUNE-DAQ/snbmodules.git -b develop
git clone https://github.com/DUNE-DAQ/trigger.git -b kbiery/integtest_trigger_choices
cd ..

cd pythoncode
git clone https://github.com/DUNE-DAQ/integrationtest.git -b kbiery/integtest_trigger_choices
cd ..

. ./env.sh
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh --verbosity 2 -r local --random 5
# and/or
dunedaq_integtest_bundle.sh --verbosity 2 -r all -R 'asiolibs|crtmodules' -x 'iceberg|ehn1' --random 5
```

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
