### PR TITLE
Update excluded_substring_map to use setdefault and extend

### DIFF
--- a/src/integrationtest/log_file_checks.py
+++ b/src/integrationtest/log_file_checks.py
@@ -107,7 +107,9 @@ def logs_are_error_free(log_file_names, show_all_problems=True, print_logfilenam
     # 06-Apr-2026, KAB: if the verbosity level is set to enable DRUNC debug messages, add
     # some strings to the excluded substring map so we don't trigger on those debug messages
     if verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_debug):
-        excluded_substring_map["SSH_SHELL_process_manager"] = ["RAN:", "LogLevel=error"]
+        excluded_substring_map.setdefault("SSH_SHELL_process_manager", []).extend(
+            ["RAN:", "LogLevel=error"]
+        )
 
     all_ok=True
     #print("") # Clear potential dot from pytest


### PR DESCRIPTION
# Description

This is related to https://github.com/DUNE-DAQ/drunc/issues/932, which came about from https://github.com/DUNE-DAQ/drunc/pull/930

When fixing some of the new behaviour in drunc, I needed to add [this line (see comment)](https://github.com/DUNE-DAQ/drunc/pull/933#discussion_r3318316607) to `ignored_logfile_problems`. 

However, I noticed that this wasn't working because the relevant line in `src/integrationtest/log_file_checks.py` is continuously overriding this. This change fixes it to properly set a default as written there, but also to respect if others wanted to add their own stuff to ignore by appending the list. 



## Type of change
- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

~~- [ ] Unit tests pass (e.g. `dbt-build --unittest`)~~
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
~~- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)~~
~~- [ ] Python tests pass if applicable (e.g. `python -m pytest`)~~
~~- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)~~

**Testing suggestion**

This is tested with the relevant drunc PR. I recommend following the testing notes here https://github.com/DUNE-DAQ/drunc/pull/933 to properly test the changes.

However, the minimal test that can be done is simply by running the msqt and seeing that nothing breaks. 



## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [x] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [x] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

