### PR TITLE
Added support in integrationtest_drunc.py for finding a predefined configuration file...

### DIFF
--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -234,11 +234,21 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
 
     if isinstance(integtest_params, integtest_params_for_predefined_dunedaq_config):
         integtest_conf = integtest_params.predefined_config_db
-        if file_exists(integtest_conf):
+        # 10-Jun-2026, KAB: added support for finding the specified config_db file
+        # in one of the directories listed in the DUNEDAQ_DB_PATH env var
+        found_file = file_exists(integtest_conf)
+        if not found_file:
+            try:
+                path_string = os.environ["DUNEDAQ_DB_PATH"]
+                directories = path_string.split(":")
+                found_file = any((pathlib.Path(dd) / integtest_conf).is_file() for dd in directories if dd)
+            except KeyError:
+                pass
+        if found_file:
             print(f"Integtest preconfigured config file: {integtest_conf}")
             consolidate_files(str(temp_config_db), integtest_conf)
         else:
-            fail_msg = f"The file containing the predefined dunedaq configuration \"{integtest_conf}\" could not be found."
+            fail_msg = f"The file containing the predefined dunedaq configuration \"{integtest_conf}\" could not be found either from its absolute location or in any of the paths in DUNEDAQ_DB_PATH."
             pytest.fail(fail_msg, pytrace=False)
     else:
         dro_map_file = config_dir / "ReadoutMap.data.xml"

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -239,6 +239,9 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
         found_file = file_exists(integtest_conf)
         if not found_file:
             try:
+                # the name of a file somewhere in the DB path shouldn't have a leading slash,
+                # so we'll provide that little bit of helpfulness here
+                integtest_conf = integtest_conf.lstrip("/")
                 path_string = os.environ["DUNEDAQ_DB_PATH"]
                 directories = path_string.split(":")
                 found_file = any((pathlib.Path(dd) / integtest_conf).is_file() for dd in directories if dd)


### PR DESCRIPTION
... in one of the paths listed in the DUNEDAQ_DB_PATH env var. 

# Description

While helping Pawel debug an issue with a new `drunc` integration test, I noticed that the cross-check that the integrationtest infrastructure does to verify that a file with a pre-defined DUNE-DAQ configuration exists was not taking into account the DUNEDAQ_DB_PATH.  This seemed overly restrictive, so I added this functionality.

With this change, we don't need to specify pre-defined config files in our integetests with code like the following:

```
common_config_obj.predefined_config_db = (
    os.environ.get("DAQSYSTEMTEST_SHARE") + "/config/daqsystemtest/example-configs.data.xml"
)
```

and instead can use simpler assignments like the following:

```
common_config_obj.predefined_config_db = (
    "config/daqsystemtest/example-configs.data.xml"
)
```

Here are suggested steps for testing this change.  They locally modify an existing integtest to use the simpler pre-defined config file assignment and show that the test fails without the code change in this PR, and succeeds when the code in this PR is used.

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260610_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/crtmodules.git -b develop
cd ..

sed -i 's,os.environ.get("DAQSYSTEMTEST_SHARE") + ,,' sourcecode/crtmodules/integtest/crt_frame_builder_test.py

cd pythoncode
git clone https://github.com/DUNE-DAQ/integrationtest.git -b develop
cd ..

. ./env.sh
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -r crtmodules

echo ""
echo -e "\U1F535 \U2705 Note that the integtest failed because the specified pre-defined configuration couldn't be found. \U2705 \U1F535"
echo ""
echo ""
sleep 3

cd pythoncode/integrationtest
git checkout kbiery/added_support_dbpath
cd ../..

dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -r crtmodules

echo ""
echo -e "\U1F535 \U2705 Note that the integtest now passed because the pre-defined configuration was found in the DUNEDAQ_DB_PATH. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
