### PR TITLE
Added support for specifying drunc command-line arguments inside integtests

### DIFF
--- a/src/integrationtest/data_classes.py
+++ b/src/integrationtest/data_classes.py
@@ -67,6 +67,9 @@ class integtest_param_base_class:
     connsvc_port: int = 0
     connsvc_debug_level: int = None
 
+    # command-line arguments to be passed to run control
+    dunerc_cmd_args: list[str] = field(default_factory=list)
+
 @dataclass
 class integtest_params_for_generated_dunedaq_config(integtest_param_base_class):
     # *** Parameters that are needed for both generated and predefined configs,

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -643,8 +643,9 @@ def run_dunerc(request, create_config_files, process_manager_type, tmp_path_fact
     time_before = time.time()
     # 25-Mar-2026, KAB: use subprocess.Popen to manage the run control session so that we can
     # capture the console output and pass it back to the user for inspection and validation.
-    popen_command_list = [dunerc] + dunerc_option_strings + [process_manager_type] \
-        + [str(create_config_files.config_file)] + [str(create_config_files.config.config_session_name)] \
+    popen_command_list = [dunerc] + create_config_files.config.dunerc_cmd_args + dunerc_option_strings \
+        + [process_manager_type] + [str(create_config_files.config_file)] \
+        + [str(create_config_files.config.config_session_name)] \
         + [str(create_config_files.config.daq_session_name)] + run_control_commands
     rc_process = subprocess.Popen(
         popen_command_list,

--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -600,8 +600,8 @@ def run_dunerc(request, create_config_files, process_manager_type, cleanup_hdf5_
     time_before = time.time()
     # 25-Mar-2026, KAB: use subprocess.Popen to manage the run control session so that we can
     # capture the console output and pass it back to the user for inspection and validation.
-    popen_command_list = [dunerc] + create_config_files.config.dunerc_cmd_args + dunerc_option_strings \
-        + [process_manager_type] + [str(create_config_files.dunedaq_config_file)] \
+    popen_command_list = [dunerc] + create_config_files.integtest_params.dunerc_cmd_args \
+        + dunerc_option_strings + [process_manager_type] + [str(create_config_files.dunedaq_config_file)] \
         + [str(create_config_files.integtest_params.config_session_name)] \
         + [str(create_config_files.integtest_params.daq_session_name)] + run_control_commands
     rc_process = subprocess.Popen(


### PR DESCRIPTION
# Description

Pawel requested the ability to specify drunc command-line arguments inside integtests.  The changes in this PR provide that ability.

The changes include the addition of a `dunerc_cmd_args` field to the `integtest_param_base_class` in `data_classes.py` and the addition of the contents of that field in the startup of `drunc` in `integrationtest_drunc.py`.

To test this, one can simply include these changes in a software area based on a recent nightly build, `pip install` this package, specify one or more `drunc` command-line arguments in the `dunerc_cmd_args` parameter in an integtest, and run the integtest.

Here is a sample addition to an integtest:

```
--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -77,6 +77,7 @@ conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "minimal"
 conf_dict.tpg_enabled = False
+conf_dict.dunerc_cmd_args = ["--no-override-logs"]

 # For testing, allow drunc to manage ConnectivityService
 #conf_dict.connsvc_control = ConnSvcControl.RUNCONTROL
```

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
