### PR TITLE
Updated the logfile exclusions defined in log_file_checks::logs_are_error_free()…

### DIFF
--- a/src/integrationtest/log_file_checks.py
+++ b/src/integrationtest/log_file_checks.py
@@ -111,7 +111,8 @@ def logs_are_error_free(log_file_names, show_all_problems=True, print_logfilenam
             ["LogLevel=error", "key:\s\"DUNEDAQ_ERS_"]
         )
         excluded_substring_map.setdefault("drunc", []).extend(
-            ["LogLevel=error", "key:\s\"DUNEDAQ_ERS_", "DUNEDAQ_ERS_.*erstrace", "export DUNEDAQ_ERS_"]
+            ["LogLevel=error", "key:\s\"DUNEDAQ_ERS_", "DUNEDAQ_ERS_.*erstrace", "export DUNEDAQ_ERS_",
+             "NewConnectionError.* Failed to establish a new connection: \[Errno 111\] Connection refused"]
         )
 
     # 21-Jul-2026, KAB: phrases that we always want to exclude

--- a/src/integrationtest/log_file_checks.py
+++ b/src/integrationtest/log_file_checks.py
@@ -108,7 +108,10 @@ def logs_are_error_free(log_file_names, show_all_problems=True, print_logfilenam
     # some strings to the excluded substring map so we don't trigger on those debug messages
     if verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_debug):
         excluded_substring_map.setdefault("SSH_SHELL_process_manager", []).extend(
-            ["RAN:", "LogLevel=error"]
+            ["LogLevel=error", "key:\s\"DUNEDAQ_ERS_"]
+        )
+        excluded_substring_map.setdefault("drunc", []).extend(
+            ["LogLevel=error", "key:\s\"DUNEDAQ_ERS_", "DUNEDAQ_ERS_.*erstrace", "export DUNEDAQ_ERS_"]
         )
 
     # 21-Jul-2026, KAB: phrases that we always want to exclude


### PR DESCRIPTION
… so that when `drunc` debug messages are enabled, we don't complain about irrelevant messages.

# Description

I noticed that when I enabled a verbosity level of 6 (six) in our regression tests with a recent nightly build, there were new messages in the `drunc` debug output that caused the `log_file_checks` in the `integrationtest` infrastructure to think that there were problems with the test results, even though there weren't any problems with the test.

The changes in this PR update the centrally-defined exclusions (in the `log_file_checks.py` file) so that passing integtests are not erroneous reported as failing.

Here are suggested instructions for testing these changes:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260727_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop

cd ..

cd pythoncode
git clone https://github.com/DUNE-DAQ/integrationtest.git -b develop
cd ..

. ./env.sh
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -k small --verb 5

echo ""
echo -e "\U1F535 \U2705 Note that the SFQT integtest ran fine with verbosity level of 5. \U2705 \U1F535"
echo ""
echo ""
sleep 3

dunedaq_integtest_bundle.sh -k small --verb 6

echo ""
echo -e "\U1F535 \U2705 Note that the SFQT integtest reported problems with verbosity level of 6. \U2705 \U1F535"
echo -e "\U1F535 \U2705 (These are not real problem; they are a by-product of drunc debug mode.) \U2705 \U1F535"
echo ""
echo ""
sleep 3

cd pythoncode/integrationtest
git checkout kbiery/updated_drunc_debug_logfile_exclusions
pip install .
cd ../../

dunedaq_integtest_bundle.sh -k small --verb 6

echo ""
echo -e "\U1F535 \U2705 Note that the SFQT integtest now runs cleanly even with a verbosity level of 6. \U2705 \U1F535"
echo ""
echo ""
sleep 3

dunedaq_integtest_bundle.sh -k example --verb 6

echo ""
echo -e "\U1F535 \U2705 Note that the example_system_test also runs cleanly with a verbosity level of 6. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
