### PR TITLE
Fixed excluded substring patterns in log_file_checks.py that have backslashes…

### DIFF
--- a/src/integrationtest/log_file_checks.py
+++ b/src/integrationtest/log_file_checks.py
@@ -113,11 +113,11 @@ def logs_are_error_free(log_file_names, show_all_problems=True, print_logfilenam
     # some strings to the excluded substring map so we don't trigger on those debug messages
     if verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_debug):
         local_excl_string_map.setdefault("SSH_SHELL_process_manager", []).extend(
-            ["LogLevel=error", "key:\s\"DUNEDAQ_ERS_"]
+            ["LogLevel=error", r'key:\s+"DUNEDAQ_ERS_']
         )
         local_excl_string_map.setdefault("drunc", []).extend(
-            ["LogLevel=error", "key:\s\"DUNEDAQ_ERS_", "DUNEDAQ_ERS_.*erstrace", "export DUNEDAQ_ERS_",
-             "NewConnectionError.* Failed to establish a new connection: \[Errno 111\] Connection refused"]
+            ["LogLevel=error", r'key:\s+"DUNEDAQ_ERS_', r"DUNEDAQ_ERS_.*erstrace", "export DUNEDAQ_ERS_",
+             r"NewConnectionError.* Failed to establish a new connection: \[Errno 111\] Connection refused"]
         )
 
     # 21-Jul-2026, KAB: phrases that we always want to exclude

--- a/src/integrationtest/log_file_checks.py
+++ b/src/integrationtest/log_file_checks.py
@@ -118,7 +118,8 @@ def logs_are_error_free(log_file_names, show_all_problems=True, print_logfilenam
         )
         local_excl_string_map.setdefault("drunc", []).extend(
             ["LogLevel=error", r'key:\s+"DUNEDAQ_ERS_', r"DUNEDAQ_ERS_.*erstrace", "export DUNEDAQ_ERS_",
-             r"NewConnectionError.* Failed to establish a new connection: \[Errno 111\] Connection refused"]
+             r"NewConnectionError.* Failed to establish a new connection: \[Errno 111\] Connection refused",
+             r"drunc.utils.ConnectivityServiceClient\s+404 Client Error: NOT FOUND for url:"]
         )
 
     # 21-Jul-2026, KAB: phrases that we always want to exclude

--- a/src/integrationtest/log_file_checks.py
+++ b/src/integrationtest/log_file_checks.py
@@ -113,7 +113,8 @@ def logs_are_error_free(log_file_names, show_all_problems=True, print_logfilenam
     # some strings to the excluded substring map so we don't trigger on those debug messages
     if verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_debug):
         local_excl_string_map.setdefault("SSH_SHELL_process_manager", []).extend(
-            ["LogLevel=error", r'key:\s+"DUNEDAQ_ERS_']
+            ["LogLevel=error", r'key:\s+"DUNEDAQ_ERS_',
+             r"drunc.utils.ConnectivityServiceClient\s+404 Client Error: NOT FOUND for url:"]
         )
         local_excl_string_map.setdefault("drunc", []).extend(
             ["LogLevel=error", r'key:\s+"DUNEDAQ_ERS_', r"DUNEDAQ_ERS_.*erstrace", "export DUNEDAQ_ERS_",


### PR DESCRIPTION
… to be raw strings

# Description

Earlier today, Michal reported that he noticed messages like the following when running regression tests like `minimal_system_quick_test` with the latest nightly build:

```
=============================== warnings summary ===============================
.venv/lib/python3.12/site-packages/integrationtest/log_file_checks.py:111
  /home/nfs/biery/dunedaq/03AugFDDevTest730_1552/.venv/lib/python3.12/site-packages/integrationtest/log_file_checks.py:111: SyntaxWarning: invalid escape sequence '\s'
    ["LogLevel=error", "key:\s\"DUNEDAQ_ERS_"]

.venv/lib/python3.12/site-packages/integrationtest/log_file_checks.py:114
  /home/nfs/biery/dunedaq/03AugFDDevTest730_1552/.venv/lib/python3.12/site-packages/integrationtest/log_file_checks.py:114: SyntaxWarning: invalid escape sequence '\s'
    ["LogLevel=error", "key:\s\"DUNEDAQ_ERS_", "DUNEDAQ_ERS_.*erstrace", "export DUNEDAQ_ERS_",

.venv/lib/python3.12/site-packages/integrationtest/log_file_checks.py:115
  /home/nfs/biery/dunedaq/03AugFDDevTest730_1552/.venv/lib/python3.12/site-packages/integrationtest/log_file_checks.py:115: SyntaxWarning: invalid escape sequence '\['
    "NewConnectionError.* Failed to establish a new connection: \[Errno 111\] Connection refused"]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 3 passed, 3 warnings in 59.57s ========================
```

It seems that this problem can only be seen when the first integtest is run after a new local software area is created.  That's pretty weird, but I believe that the problem originated when I added extra "excluded substrings" to `log_file_checks.py`.  

This PR has improvements in the way that the excluded substrings are declared, and I'm hopeful that these changes will eliminate the messages that Michal reported.

I've confirmed that a sampling of regression tests continues to run normally with these changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
