### PR TITLE
Removed the disable_connectivity_service argument from the generate_session call…

### DIFF
--- a/src/integrationtest/integrationtest_drunc.py
+++ b/src/integrationtest/integrationtest_drunc.py
@@ -290,7 +290,6 @@ def create_config_files(request, tmp_path_factory, check_system_resources):
             session_name=integtest_params.config_session_name,
             op_env=integtest_params.op_env,
             connectivity_service_is_infrastructure_app=runcontrol_starts_connsvc,
-            disable_connectivity_service=no_integtest_connsvc,
         )
 
     consolidate_db(str(temp_config_db), str(config_db))


### PR DESCRIPTION
…in `integrationtest_drunc.py` because we now believe that we should always include the ConnectivityService in the OKS session when we generate a DAQ configuration.

# Description

Please see DUNE-DAQ/daqconf#634 for a description of this change and instructions for testing it.

